### PR TITLE
Add complex dense tensor support

### DIFF
--- a/Sources/AccelerateWrapper/AccelerateOperations.swift
+++ b/Sources/AccelerateWrapper/AccelerateOperations.swift
@@ -111,5 +111,29 @@ public struct AccelerateOperations {
         Accelerate.dgesv_(&nMutable, &nrhs, a, &lda, &ipiv, b, &ldb, &info)
         return info
     }
+
+    public static func zgesv(
+        _ n: Int32,
+        _ a: inout [Double],
+        _ b: inout [Double]
+    ) -> Int32 {
+        var nMutable = n
+        var nrhs = Int32(1)
+        var lda = n
+        var ipiv = Array<Int32>(repeating: 0, count: Int(n))
+        var ldb = n
+        var info = Int32(0)
+
+        a.withUnsafeMutableBufferPointer { a in
+            b.withUnsafeMutableBufferPointer { b in
+                Accelerate.zgesv_(
+                    &nMutable, &nrhs,
+                    OpaquePointer(UnsafeMutableRawPointer(a.baseAddress!)), &lda, &ipiv,
+                    OpaquePointer(UnsafeMutableRawPointer(b.baseAddress!)), &ldb, &info
+                )
+            }
+        }
+        return info
+    }
 }
 #endif

--- a/Sources/AccelerateWrapper/AccelerateOperations.swift
+++ b/Sources/AccelerateWrapper/AccelerateOperations.swift
@@ -16,6 +16,38 @@ public struct AccelerateOperations {
 
         Accelerate.cblas_dgemv(CblasColMajor, CblasNoTrans, m, n, alpha, a, lda, x, incx, beta, y, incy)
     }
+
+    public static func zgemv(
+        _ m: Int32, _ n: Int32,
+        _ a: inout [Double],
+        _ x: inout [Double],
+        _ y: inout [Double]
+    ) {
+        var alpha = [1.0, 0.0]
+        var beta = [0.0, 0.0]
+        let lda = Int32(m)
+        let incx = Int32(1)
+        let incy = Int32(1)
+
+        alpha.withUnsafeMutableBufferPointer { alpha in
+            beta.withUnsafeMutableBufferPointer { beta in
+                a.withUnsafeMutableBufferPointer { a in
+                    x.withUnsafeMutableBufferPointer { x in
+                        y.withUnsafeMutableBufferPointer { y in
+                            Accelerate.cblas_zgemv(
+                                CblasColMajor, CblasNoTrans, m, n,
+                                OpaquePointer(UnsafeMutableRawPointer(alpha.baseAddress!)),
+                                OpaquePointer(UnsafeMutableRawPointer(a.baseAddress!)), lda,
+                                OpaquePointer(UnsafeMutableRawPointer(x.baseAddress!)), incx,
+                                OpaquePointer(UnsafeMutableRawPointer(beta.baseAddress!)),
+                                OpaquePointer(UnsafeMutableRawPointer(y.baseAddress!)), incy
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
     
     public static func dgemm(
         _ m: Int32, _ n: Int32, _ k: Int32,
@@ -29,6 +61,38 @@ public struct AccelerateOperations {
         let ldb = k
         let ldc = m
         Accelerate.cblas_dgemm(CblasColMajor, CblasNoTrans, CblasNoTrans, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc)
+    }
+
+    public static func zgemm(
+        _ m: Int32, _ n: Int32, _ k: Int32,
+        _ a: inout [Double],
+        _ b: inout [Double],
+        _ c: inout [Double]
+    ) {
+        var alpha = [1.0, 0.0]
+        var beta = [0.0, 0.0]
+        let lda = m
+        let ldb = k
+        let ldc = m
+
+        alpha.withUnsafeMutableBufferPointer { alpha in
+            beta.withUnsafeMutableBufferPointer { beta in
+                a.withUnsafeMutableBufferPointer { a in
+                    b.withUnsafeMutableBufferPointer { b in
+                        c.withUnsafeMutableBufferPointer { c in
+                            Accelerate.cblas_zgemm(
+                                CblasColMajor, CblasNoTrans, CblasNoTrans, m, n, k,
+                                OpaquePointer(UnsafeMutableRawPointer(alpha.baseAddress!)),
+                                OpaquePointer(UnsafeMutableRawPointer(a.baseAddress!)), lda,
+                                OpaquePointer(UnsafeMutableRawPointer(b.baseAddress!)), ldb,
+                                OpaquePointer(UnsafeMutableRawPointer(beta.baseAddress!)),
+                                OpaquePointer(UnsafeMutableRawPointer(c.baseAddress!)), ldc
+                            )
+                        }
+                    }
+                }
+            }
+        }
     }
 
     // MARK: - LAPACK

--- a/Sources/LinearSolvers/DenseLinearSolvers.swift
+++ b/Sources/LinearSolvers/DenseLinearSolvers.swift
@@ -26,11 +26,31 @@ public func solveLinearDense<M: PluMatrix, V: PluVector>(_ A: M, _ b: V, blasImp
             x = bArray as! [V.S]
         }
     case is Complex.Type:
-        fatalError("Not yet implemented")
+        var AArray = interleaved(A.flatten() as! [Complex])
+        var bArray = interleaved(b.toArray() as! [Complex])
+
+        switch blasImplementation {
+        #if canImport(Accelerate)
+        case .accelerate:
+            let _ = AccelerateOperations.zgesv(Int32(n), &AArray, &bArray)
+            x = complexValues(bArray) as! [V.S]
+        #endif
+        case .openBLAS:
+            let _ = OpenBLASOperations.zgesv(Int32(n), &AArray, &bArray)
+            x = complexValues(bArray) as! [V.S]
+        }
 
     default:
         fatalError("Unsupported scalar type")
     }
 
     return V(x)
+}
+
+private func interleaved(_ values: [Complex]) -> [Double] {
+    values.flatMap { [$0.real, $0.imaginary] }
+}
+
+private func complexValues(_ values: [Double]) -> [Complex] {
+    stride(from: 0, to: values.count, by: 2).map { Complex(values[$0], values[$0 + 1]) }
 }

--- a/Sources/OpenBLASWrapper/OpenBLASOperations.swift
+++ b/Sources/OpenBLASWrapper/OpenBLASOperations.swift
@@ -16,6 +16,35 @@ public enum OpenBLASOperations {
         
         COpenBLAS.cblas_dgemv(CblasColMajor, CblasNoTrans, m, n, alpha, a, lda, x, incx, beta, y, incy)
     }
+
+    public static func zgemv(
+        _ m: Int32, _ n: Int32,
+        _ a: inout [Double],
+        _ x: inout [Double],
+        _ y: inout [Double]
+    ) {
+        var alpha = [1.0, 0.0]
+        var beta = [0.0, 0.0]
+        let lda = Int32(m)
+        let incx = Int32(1)
+        let incy = Int32(1)
+
+        alpha.withUnsafeMutableBufferPointer { alpha in
+            beta.withUnsafeMutableBufferPointer { beta in
+                a.withUnsafeMutableBufferPointer { a in
+                    x.withUnsafeMutableBufferPointer { x in
+                        y.withUnsafeMutableBufferPointer { y in
+                            COpenBLAS.cblas_zgemv(
+                                CblasColMajor, CblasNoTrans, m, n,
+                                alpha.baseAddress, a.baseAddress, lda, x.baseAddress, incx,
+                                beta.baseAddress, y.baseAddress, incy
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
     
     public static func dgemm(
         _ m: Int32, _ n: Int32, _ k: Int32,
@@ -29,6 +58,35 @@ public enum OpenBLASOperations {
         let ldb = k
         let ldc = m
         COpenBLAS.cblas_dgemm(CblasColMajor, CblasNoTrans, CblasNoTrans, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc)
+    }
+
+    public static func zgemm(
+        _ m: Int32, _ n: Int32, _ k: Int32,
+        _ a: inout [Double],
+        _ b: inout [Double],
+        _ c: inout [Double]
+    ) {
+        var alpha = [1.0, 0.0]
+        var beta = [0.0, 0.0]
+        let lda = m
+        let ldb = k
+        let ldc = m
+
+        alpha.withUnsafeMutableBufferPointer { alpha in
+            beta.withUnsafeMutableBufferPointer { beta in
+                a.withUnsafeMutableBufferPointer { a in
+                    b.withUnsafeMutableBufferPointer { b in
+                        c.withUnsafeMutableBufferPointer { c in
+                            COpenBLAS.cblas_zgemm(
+                                CblasColMajor, CblasNoTrans, CblasNoTrans, m, n, k,
+                                alpha.baseAddress, a.baseAddress, lda, b.baseAddress, ldb,
+                                beta.baseAddress, c.baseAddress, ldc
+                            )
+                        }
+                    }
+                }
+            }
+        }
     }
 
     // MARK: - LAPACK

--- a/Sources/OpenBLASWrapper/OpenBLASOperations.swift
+++ b/Sources/OpenBLASWrapper/OpenBLASOperations.swift
@@ -105,4 +105,28 @@ public enum OpenBLASOperations {
         COpenBLAS.dgesv_(&nMutable, &nrhs, a, &lda, &ipiv, b, &ldb, &info)
         return info
     }
+
+    public static func zgesv(
+        _ n: Int32,
+        _ a: inout [Double],
+        _ b: inout [Double]
+    ) -> Int32 {
+        var nMutable = n
+        var nrhs = Int32(1)
+        var lda = n
+        var ipiv = Array<Int32>(repeating: 0, count: Int(n))
+        var ldb = n
+        var info = Int32(0)
+
+        _ = a.withUnsafeMutableBufferPointer { a in
+            b.withUnsafeMutableBufferPointer { b in
+                COpenBLAS.zgesv_(
+                    &nMutable, &nrhs,
+                    OpaquePointer(UnsafeMutableRawPointer(a.baseAddress!)), &lda, &ipiv,
+                    OpaquePointer(UnsafeMutableRawPointer(b.baseAddress!)), &ldb, &info
+                )
+            }
+        }
+        return info
+    }
 }

--- a/Sources/Tensors/MatrixDenseBLAS.swift
+++ b/Sources/Tensors/MatrixDenseBLAS.swift
@@ -214,7 +214,7 @@ public struct MatrixDenseBLAS<S: PluScalar>: PluMatrix, TensorElementwiseArithme
             }
             return MatrixDenseBLAS(rows: rows, columns: m.columns, values: MatrixDenseBLAS.complexValues(C) as! [S])
         default:
-            fatalError("Not yet implemented")
+            fatalError("Unsupported scalar type")
         }
     }
 

--- a/Sources/Tensors/MatrixDenseBLAS.swift
+++ b/Sources/Tensors/MatrixDenseBLAS.swift
@@ -148,13 +148,12 @@ public struct MatrixDenseBLAS<S: PluScalar>: PluMatrix, TensorElementwiseArithme
     public func times<V: PluVector>(_ v: V) -> V where V.S == S {
         precondition(columns == v.size, "Number of columns in matrix must equal size of vector")
         
-        var y = Array(repeating: 0.0, count: rows)
-        
         switch S.self {
         case is Double.Type:
             var A = flatten() as! [Double] // Ax = y
             var x = v.toArray(round: false) as! [Double]
-            
+            var y = Array(repeating: 0.0, count: rows)
+
             switch blasImplementation {
             #if canImport(Accelerate)
             case .accelerate:
@@ -163,13 +162,26 @@ public struct MatrixDenseBLAS<S: PluScalar>: PluMatrix, TensorElementwiseArithme
             case .openBLAS:
                 OpenBLASOperations.dgemv(Int32(rows), Int32(columns), &A, &x, &y)
             }
+
+            return V(y as! [S])
         case is Complex.Type:
-            fatalError("Not yet implemented")
+            var A = MatrixDenseBLAS.interleaved(flatten() as! [Complex])
+            var x = MatrixDenseBLAS.interleaved(v.toArray(round: false) as! [Complex])
+            var y = Array(repeating: 0.0, count: rows * 2)
+
+            switch blasImplementation {
+            #if canImport(Accelerate)
+            case .accelerate:
+                AccelerateOperations.zgemv(Int32(rows), Int32(columns), &A, &x, &y)
+            #endif
+            case .openBLAS:
+                OpenBLASOperations.zgemv(Int32(rows), Int32(columns), &A, &x, &y)
+            }
+
+            return V(MatrixDenseBLAS.complexValues(y) as! [S])
         default:
             fatalError("Unsupported scalar type")
         }
-        
-        return V(y as! [S])
     }
 
     public func times<M: PluMatrix>(_ m: M) -> MatrixDenseBLAS<S> where M.S == S {
@@ -189,7 +201,18 @@ public struct MatrixDenseBLAS<S: PluScalar>: PluMatrix, TensorElementwiseArithme
             }
             return MatrixDenseBLAS(rows: rows, columns: m.columns, values: C as! [S])
         case is Complex.Type:
-            fatalError("Not yet implemented")
+            var A = MatrixDenseBLAS.interleaved(flatten() as! [Complex])
+            var B = MatrixDenseBLAS.interleaved(m.flatten() as! [Complex])
+            var C = Array(repeating: 0.0, count: rows * m.columns * 2)
+            switch blasImplementation {
+            #if canImport(Accelerate)
+            case .accelerate:
+                AccelerateOperations.zgemm(Int32(rows), Int32(m.columns), Int32(columns), &A, &B, &C)
+            #endif
+            case .openBLAS:
+                OpenBLASOperations.zgemm(Int32(rows), Int32(m.columns), Int32(columns), &A, &B, &C)
+            }
+            return MatrixDenseBLAS(rows: rows, columns: m.columns, values: MatrixDenseBLAS.complexValues(C) as! [S])
         default:
             fatalError("Not yet implemented")
         }
@@ -231,5 +254,13 @@ public struct MatrixDenseBLAS<S: PluScalar>: PluMatrix, TensorElementwiseArithme
             }
         }
         return elements
+    }
+
+    private static func interleaved(_ values: [Complex]) -> [Double] {
+        values.flatMap { [$0.real, $0.imaginary] }
+    }
+
+    private static func complexValues(_ values: [Double]) -> [Complex] {
+        stride(from: 0, to: values.count, by: 2).map { Complex(values[$0], values[$0 + 1]) }
     }
 }

--- a/Sources/Tensors/PluScalar.swift
+++ b/Sources/Tensors/PluScalar.swift
@@ -34,6 +34,38 @@ extension Complex: PluTensor, PluScalar, ComplexScalar {
     }
 }
 
+public func + (left: Double, right: Complex) -> Complex {
+    Complex(left, 0.0) + right
+}
+
+public func + (left: Complex, right: Double) -> Complex {
+    left + Complex(right, 0.0)
+}
+
+public func - (left: Double, right: Complex) -> Complex {
+    Complex(left, 0.0) - right
+}
+
+public func - (left: Complex, right: Double) -> Complex {
+    left - Complex(right, 0.0)
+}
+
+public func * (left: Double, right: Complex) -> Complex {
+    Complex(left, 0.0) * right
+}
+
+public func * (left: Complex, right: Double) -> Complex {
+    left * Complex(right, 0.0)
+}
+
+public func / (left: Double, right: Complex) -> Complex {
+    Complex(left, 0.0) / right
+}
+
+public func / (left: Complex, right: Double) -> Complex {
+    left / Complex(right, 0.0)
+}
+
 extension PluScalar {
     public func round() -> Self {
         round(precision: 14)

--- a/Sources/Tensors/PluScalar.swift
+++ b/Sources/Tensors/PluScalar.swift
@@ -10,7 +10,6 @@ public protocol PluScalar: ElementaryFunctions & PluTensor & Numeric {
 
 public protocol ComplexScalar: PluScalar {
     var star: Self { get }
-    var dagger: Self { get }
     var mod: Magnitude { get }
     var arg: Magnitude { get }
 }
@@ -26,7 +25,6 @@ extension Double: PluScalar {
 extension Complex: PluTensor, PluScalar, ComplexScalar {
     // MARK: - ComplexScalar conformance
     public var star: Complex { conjugate }
-    public var dagger: Complex { star }
     public var mod: Double { length }
     public var arg: Double { phase }
 

--- a/Sources/Tensors/PluScalar.swift
+++ b/Sources/Tensors/PluScalar.swift
@@ -5,21 +5,39 @@ public typealias Complex = Numerics.Complex<Double>
 
 public protocol PluScalar: ElementaryFunctions & PluTensor & Numeric {
     static func / (lhs: Self, rhs: Self) -> Self
-    func round() -> Self
+    func round(precision: Int) -> Self
+}
+
+public protocol ComplexScalar: PluScalar {
+    var star: Self { get }
+    var dagger: Self { get }
+    var mod: Magnitude { get }
+    var arg: Magnitude { get }
 }
 
 extension Double: PluScalar {
     // MARK: - PluScalar conformance
-    public func round() -> Double {
-        let precision = 14
+    public func round(precision: Int = 14) -> Double {
         let multiplier = Foundation.pow(10.0, Double(precision))
         return (self * multiplier).rounded() / multiplier
     }
 }
 
-extension Complex: PluTensor, PluScalar {
+extension Complex: PluTensor, PluScalar, ComplexScalar {
+    // MARK: - ComplexScalar conformance
+    public var star: Complex { conjugate }
+    public var dagger: Complex { star }
+    public var mod: Double { length }
+    public var arg: Double { phase }
+
     // MARK: - PluScalar conformance
-    public func round() -> Complex {
-        return Complex(real.round(), imaginary.round())
+    public func round(precision: Int = 14) -> Complex {
+        return Complex(real.round(precision: precision), imaginary.round(precision: precision))
+    }
+}
+
+extension PluScalar {
+    public func round() -> Self {
+        round(precision: 14)
     }
 }

--- a/Sources/Tensors/TensorMixedScalarArithmetic.swift
+++ b/Sources/Tensors/TensorMixedScalarArithmetic.swift
@@ -1,0 +1,55 @@
+private func mixedScalarIndexCombinations(for shape: [Int]) -> [[Int]] {
+    if shape.isEmpty { return [[]] }
+    if shape.contains(0) { return [] }
+    return (0..<shape.reduce(1, *)).map { flatIndex in
+        var remaining = flatIndex
+        return shape.map { dimension in
+            let index = remaining % dimension
+            remaining /= dimension
+            return index
+        }
+    }
+}
+
+public func * <T: TensorElementwiseArithmetic>(tensor: T, scalar: Complex) -> TensorDenseBLAS<Complex>
+where T.S == Double {
+    var result = TensorDenseBLAS<Complex>(shape: tensor.shape, initialValue: .zero)
+    for index in mixedScalarIndexCombinations(for: tensor.shape) {
+        result[index] = tensor[index] * scalar
+    }
+    return result
+}
+
+public func * <T: TensorElementwiseArithmetic>(scalar: Complex, tensor: T) -> TensorDenseBLAS<Complex>
+where T.S == Double {
+    tensor * scalar
+}
+
+public func / <T: TensorElementwiseArithmetic>(tensor: T, scalar: Complex) -> TensorDenseBLAS<Complex>
+where T.S == Double {
+    var result = TensorDenseBLAS<Complex>(shape: tensor.shape, initialValue: .zero)
+    for index in mixedScalarIndexCombinations(for: tensor.shape) {
+        result[index] = tensor[index] / scalar
+    }
+    return result
+}
+
+public func * <T: TensorElementwiseArithmetic>(tensor: T, scalar: Double) -> T where T.S == Complex {
+    var result = T(shape: tensor.shape, initialValue: .zero)
+    for index in mixedScalarIndexCombinations(for: tensor.shape) {
+        result[index] = tensor[index] * scalar
+    }
+    return result
+}
+
+public func * <T: TensorElementwiseArithmetic>(scalar: Double, tensor: T) -> T where T.S == Complex {
+    tensor * scalar
+}
+
+public func / <T: TensorElementwiseArithmetic>(tensor: T, scalar: Double) -> T where T.S == Complex {
+    var result = T(shape: tensor.shape, initialValue: .zero)
+    for index in mixedScalarIndexCombinations(for: tensor.shape) {
+        result[index] = tensor[index] / scalar
+    }
+    return result
+}

--- a/Tests/LinearSolversTests/DenseLinearSolverTests.swift
+++ b/Tests/LinearSolversTests/DenseLinearSolverTests.swift
@@ -40,6 +40,16 @@ func solveLinearDense_correctness_smallMatrices<MatrixType: PluMatrix>(matrixTyp
     solveLinearDense_correctness_smallMatrices(matrixType: MatrixDenseBLAS<Double>.self)
 }
 
+@Test func solveLinearDense_complexBLAS() {
+    let A = MatrixDenseBLAS<Complex>([[Complex(1.0, 0.0), Complex(0.0, 1.0)],
+                                      [Complex(2.0, -1.0), Complex(1.0, 1.0)]])
+    let b = VectorDenseReference<Complex>([Complex(2.0, 3.0), Complex(6.0, 2.0)])
+    let expected = VectorDenseReference<Complex>([Complex(1.0, 1.0), Complex(2.0, -1.0)])
+    let actual = solveLinearDense(A, b)
+
+    #expect(actual.isApproximatelyEqual(to: expected, relativeTolerance: 1e-12))
+}
+
 func solveLinearDense_correctness_largeMatrices<MatrixType: PluMatrix>(matrixType: MatrixType.Type)
         where MatrixType.S == Double {
     let sizes = [100, 500]

--- a/Tests/LinearSolversTests/DenseLinearSolverTests.swift
+++ b/Tests/LinearSolversTests/DenseLinearSolverTests.swift
@@ -48,6 +48,11 @@ func solveLinearDense_correctness_smallMatrices<MatrixType: PluMatrix>(matrixTyp
     let actual = solveLinearDense(A, b)
 
     #expect(actual.isApproximatelyEqual(to: expected, relativeTolerance: 1e-12))
+
+    #if canImport(Accelerate)
+    let accelerate = solveLinearDense(A, b, blasImplementation: .accelerate)
+    #expect(accelerate.isApproximatelyEqual(to: expected, relativeTolerance: 1e-12))
+    #endif
 }
 
 func solveLinearDense_correctness_largeMatrices<MatrixType: PluMatrix>(matrixType: MatrixType.Type)

--- a/Tests/TensorsTests/DenseMatrixBLASTests.swift
+++ b/Tests/TensorsTests/DenseMatrixBLASTests.swift
@@ -58,12 +58,33 @@ import Testing
     #expect(b == VectorDenseReference<Double>([20.0, 47.0]))
 }
 
+@Test func DenseMatrix_BLAS_complexVectorMultiplication() {
+    let A = MatrixDenseBLAS<Complex>([[Complex(1.0, 1.0), Complex(2.0, 0.0), Complex(0.0, -1.0)],
+                                      [Complex(3.0, 0.0), Complex(-1.0, 1.0), Complex(2.0, -1.0)]])
+    let v = VectorDenseReference<Complex>([Complex(1.0, 0.0), Complex(0.0, 1.0), Complex(2.0, 0.0)])
+    let b = A * v
+
+    #expect(b == VectorDenseReference<Complex>([Complex(1.0, 1.0), Complex(6.0, -3.0)]))
+}
+
 @Test func DenseMatrix_BLAS_matrixMultiplication() {
     let A = MatrixDenseBLAS<Double>([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
     let B = MatrixDenseBLAS<Double>([[7.0, 8.0], [9.0, 10.0], [11.0, 12.0]])
     let C = A * B
 
     #expect(C.toArray() == [[58.0, 64.0], [139.0, 154.0]])
+}
+
+@Test func DenseMatrix_BLAS_complexMatrixMultiplication() {
+    let A = MatrixDenseBLAS<Complex>([[Complex(1.0, 1.0), Complex(2.0, 0.0), Complex(0.0, -1.0)],
+                                      [Complex(3.0, 0.0), Complex(-1.0, 1.0), Complex(2.0, -1.0)]])
+    let B = MatrixDenseBLAS<Complex>([[Complex(1.0, 0.0), Complex(0.0, 1.0)],
+                                      [Complex(2.0, -1.0), Complex(-1.0, 0.0)],
+                                      [Complex(0.0, 0.0), Complex(1.0, 1.0)]])
+    let C = A * B
+
+    #expect(C.toArray() == [[Complex(5.0, -1.0), Complex(-2.0, 0.0)],
+                            [Complex(2.0, 3.0), Complex(4.0, 3.0)]])
 }
 
 @Test func DenseMatrix_BLAS_transpose() {

--- a/Tests/TensorsTests/DenseMatrixBLASTests.swift
+++ b/Tests/TensorsTests/DenseMatrixBLASTests.swift
@@ -59,12 +59,17 @@ import Testing
 }
 
 @Test func DenseMatrix_BLAS_complexVectorMultiplication() {
-    let A = MatrixDenseBLAS<Complex>([[Complex(1.0, 1.0), Complex(2.0, 0.0), Complex(0.0, -1.0)],
-                                      [Complex(3.0, 0.0), Complex(-1.0, 1.0), Complex(2.0, -1.0)]])
+    let A = complexTestMatrixA()
     let v = VectorDenseReference<Complex>([Complex(1.0, 0.0), Complex(0.0, 1.0), Complex(2.0, 0.0)])
     let b = A * v
 
     #expect(b == VectorDenseReference<Complex>([Complex(1.0, 1.0), Complex(6.0, -3.0)]))
+
+    #if canImport(Accelerate)
+    var AAccelerate = A
+    AAccelerate.blasImplementation = .accelerate
+    #expect(AAccelerate * v == b)
+    #endif
 }
 
 @Test func DenseMatrix_BLAS_matrixMultiplication() {
@@ -76,8 +81,7 @@ import Testing
 }
 
 @Test func DenseMatrix_BLAS_complexMatrixMultiplication() {
-    let A = MatrixDenseBLAS<Complex>([[Complex(1.0, 1.0), Complex(2.0, 0.0), Complex(0.0, -1.0)],
-                                      [Complex(3.0, 0.0), Complex(-1.0, 1.0), Complex(2.0, -1.0)]])
+    let A = complexTestMatrixA()
     let B = MatrixDenseBLAS<Complex>([[Complex(1.0, 0.0), Complex(0.0, 1.0)],
                                       [Complex(2.0, -1.0), Complex(-1.0, 0.0)],
                                       [Complex(0.0, 0.0), Complex(1.0, 1.0)]])
@@ -85,6 +89,12 @@ import Testing
 
     #expect(C.toArray() == [[Complex(5.0, -1.0), Complex(-2.0, 0.0)],
                             [Complex(2.0, 3.0), Complex(4.0, 3.0)]])
+
+    #if canImport(Accelerate)
+    var AAccelerate = A
+    AAccelerate.blasImplementation = .accelerate
+    #expect((AAccelerate * B).toArray() == C.toArray())
+    #endif
 }
 
 @Test func DenseMatrix_BLAS_transpose() {
@@ -190,4 +200,9 @@ import Testing
     let column: VectorFlatView<Double> = matrix[all, 1]
     
     #expect(column.elements == [2.0, 5.0, 8.0])
+}
+
+private func complexTestMatrixA() -> MatrixDenseBLAS<Complex> {
+    MatrixDenseBLAS<Complex>([[Complex(1.0, 1.0), Complex(2.0, 0.0), Complex(0.0, -1.0)],
+                              [Complex(3.0, 0.0), Complex(-1.0, 1.0), Complex(2.0, -1.0)]])
 }

--- a/Tests/TensorsTests/ScalarTests.swift
+++ b/Tests/TensorsTests/ScalarTests.swift
@@ -25,7 +25,6 @@ import Testing
     let z = Complex(3.0, 4.0)
 
     #expect(z.star == Complex(3.0, -4.0))
-    #expect(z.dagger == z.star)
     #expect(z.mod == 5.0)
     #expect(z.arg.isApproximatelyEqual(to: 0.9272952180016122, relativeTolerance: 1e-15))
 }

--- a/Tests/TensorsTests/ScalarTests.swift
+++ b/Tests/TensorsTests/ScalarTests.swift
@@ -17,4 +17,21 @@ import Testing
     #expect(a+b == Complex(4.6, 3.3))
     #expect(a+b == b+a)
     #expect((a-b).isApproximatelyEqual(to: Complex(-2.2, -7.9)))
+    #expect((a*b).isApproximatelyEqual(to: Complex(16.96, -1.1)))
+    #expect((a/b).isApproximatelyEqual(to: Complex(-0.20503261882572227, -0.3387698042870456)))
+}
+
+@Test func Complex_plumeriaScalarProperties() {
+    let z = Complex(3.0, 4.0)
+
+    #expect(z.star == Complex(3.0, -4.0))
+    #expect(z.dagger == z.star)
+    #expect(z.mod == 5.0)
+    #expect(z.arg.isApproximatelyEqual(to: 0.9272952180016122, relativeTolerance: 1e-15))
+}
+
+@Test func PluScalar_roundsWithPrecision() {
+    #expect(1.23456.round() == 1.23456)
+    #expect(1.23456.round(precision: 2) == 1.23)
+    #expect(Complex(1.23456, -2.34567).round(precision: 2) == Complex(1.23, -2.35))
 }

--- a/Tests/TensorsTests/ScalarTests.swift
+++ b/Tests/TensorsTests/ScalarTests.swift
@@ -21,6 +21,19 @@ import Testing
     #expect((a/b).isApproximatelyEqual(to: Complex(-0.20503261882572227, -0.3387698042870456)))
 }
 
+@Test func Complex_mixedRealArithmetic() {
+    let z = Complex(3.0, -2.0)
+
+    #expect(5.0 + z == Complex(8.0, -2.0))
+    #expect(z + 5.0 == Complex(8.0, -2.0))
+    #expect(5.0 - z == Complex(2.0, 2.0))
+    #expect(z - 5.0 == Complex(-2.0, -2.0))
+    #expect(5.0 * z == Complex(15.0, -10.0))
+    #expect(z * 5.0 == Complex(15.0, -10.0))
+    #expect((5.0 / z).isApproximatelyEqual(to: Complex(15.0/13.0, 10.0/13.0)))
+    #expect((z / 5.0).isApproximatelyEqual(to: Complex(0.6, -0.4)))
+}
+
 @Test func Complex_plumeriaScalarProperties() {
     let z = Complex(3.0, 4.0)
 

--- a/Tests/TensorsTests/TensorDenseBLASTests.swift
+++ b/Tests/TensorsTests/TensorDenseBLASTests.swift
@@ -55,6 +55,29 @@ private func tensor(_ values: [[[Double]]]) -> TensorDenseBLAS<Double> {
     #expect(sum.isApproximatelyEqual(to: sum, relativeTolerance: 1e-12))
 }
 
+@Test func TensorDenseBLAS_mixedScalarArithmetic() {
+    let realScalar = TensorDenseBLAS<Double>(shape: [], elements: [2.0])
+    let realRank3 = TensorDenseBLAS<Double>(shape: [2, 2, 2], elements: [1.0, 0.0, -1.0, 2.0, 3.0, -2.0, 0.0, 1.0])
+    let complexRank3 = TensorDenseBLAS<Complex>(shape: [2, 2, 2], elements: [
+        Complex(1.0, -1.0), Complex(0.0, 2.0), Complex(-1.0, 0.0), Complex(2.0, 1.0),
+        Complex(3.0, -2.0), Complex(-2.0, 1.0), Complex(0.0, -1.0), Complex(1.0, 0.0)
+    ])
+    #expect((realScalar * Complex(1.0, -1.0)).elements == [Complex(2.0, -2.0)])
+    #expect((realRank3 * Complex(0.0, 2.0)).elements == [
+        Complex(0.0, 2.0), Complex(0.0, 0.0), Complex(0.0, -2.0), Complex(0.0, 4.0),
+        Complex(0.0, 6.0), Complex(0.0, -4.0), Complex(0.0, 0.0), Complex(0.0, 2.0)
+    ])
+    #expect((Complex(0.0, 2.0) * realRank3).elements == (realRank3 * Complex(0.0, 2.0)).elements)
+    #expect((complexRank3 * 2.0).elements == [
+        Complex(2.0, -2.0), Complex(0.0, 4.0), Complex(-2.0, 0.0), Complex(4.0, 2.0),
+        Complex(6.0, -4.0), Complex(-4.0, 2.0), Complex(0.0, -2.0), Complex(2.0, 0.0)
+    ])
+    #expect((complexRank3 / 2.0).elements == [
+        Complex(0.5, -0.5), Complex(0.0, 1.0), Complex(-0.5, 0.0), Complex(1.0, 0.5),
+        Complex(1.5, -1.0), Complex(-1.0, 0.5), Complex(0.0, -0.5), Complex(0.5, 0.0)
+    ])
+}
+
 @Test func TensorDenseBLAS_outerProduct() {
     let left = TensorDenseBLAS<Double>(shape: [2], elements: [2.0, -1.0])
     let right = TensorDenseBLAS<Double>(shape: [3], elements: [3.0, 0.0, -2.0])


### PR DESCRIPTION
Adds the complex scalar API (, , ), complex dense BLAS matrix-vector and matrix-matrix multiplication, and complex dense linear solving. Also adds coverage for both the OpenBLAS and Accelerate paths with small hand-checkable examples.