### PR TITLE
Add tensor conveniences

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,13 @@
+# Plumeria Mathematics Instructions
+
+## Project Preferences
+
+- Do not use broadcasting semantics: do not implicitly expand scalars or lower-rank tensors across tensor axes for elementwise operations.
+- Do not add scalar addition for tensors. Tensor-scalar multiplication and division are acceptable.
+- Do not add Hadamard products unless there is a concrete physics use case.
+- Reference implementations should be naive and math-like, resembling academic arithmetic rather than optimized storage algorithms.
+- BLAS implementations should use BLAS-backed operations where BLAS behavior is the purpose of the implementation.
+- Keep protocols storage-agnostic where practical. Put shared behavior at the highest clean protocol level without polluting real tensors or scalars with complex-only behavior.
+- Prefer physics conventions for tensor multiplication: repeated indices contract; free indices remain in written order; do not add an explicit binary output clause.
+- Keep tests human-checkable: small tensors, concrete values, simple arithmetic, and parameterized reference/BLAS coverage where appropriate.
+- Use concise math-native API names where appropriate, such as `t`, `tr`, `det`, `inverse()`, `magnitude()`, `eigen()`, `star`, `mod`, and `arg`.

--- a/Sources/Tensors/Core/PluScalar.swift
+++ b/Sources/Tensors/Core/PluScalar.swift
@@ -28,6 +28,8 @@ extension Complex: TensorArithmetic, PluTensor, PluScalar, ComplexScalar {
     // MARK: - ComplexScalar conformance
     public typealias S = Complex
 
+    public static let i = Complex(0.0, 1.0)
+
     public var star: Complex { conjugate }
     public var mod: Double { length }
     public var arg: Double { phase }

--- a/Sources/Tensors/Matrix/MatrixDenseBLAS.swift
+++ b/Sources/Tensors/Matrix/MatrixDenseBLAS.swift
@@ -46,6 +46,12 @@ public struct MatrixDenseBLAS<S: PluScalar>: PluMatrix, TensorArithmeticBLAS {
         self.blasImplementation = .openBLAS
     }
 
+    public init(_ values: TensorNestedArray<S>) {
+        precondition(values.shape.count == 2, "Matrix nested array must have rank 2")
+        self.view = TensorFlatView(values)
+        self.blasImplementation = .openBLAS
+    }
+
     public var elements: [S] {
         get { viewElements(columnMajorOrder: true) }
         set {

--- a/Sources/Tensors/Matrix/MatrixDenseReference.swift
+++ b/Sources/Tensors/Matrix/MatrixDenseReference.swift
@@ -38,6 +38,11 @@ public struct MatrixDenseReference<S: PluScalar>: PluMatrix, TensorArithmeticRef
         
         self.values = values
     }
+
+    public init(_ values: TensorNestedArray<S>) {
+        precondition(values.shape.count == 2, "Matrix nested array must have rank 2")
+        self.init(Self.rows(from: values))
+    }
         
     public func times<V: PluVector>(_ v: V) -> V where S == V.S {
         precondition(self.columns == v.size, "Matrix columns don't match vector size")
@@ -98,6 +103,13 @@ public struct MatrixDenseReference<S: PluScalar>: PluMatrix, TensorArithmeticRef
             return flattened
         } else {
             return Array(values.joined())
+        }
+    }
+
+    private static func rows(from values: TensorNestedArray<S>) -> [[S]] {
+        let shape = values.shape
+        return (0..<shape[0]).map { row in
+            (0..<shape[1]).map { column in values[[row, column]] }
         }
     }
     

--- a/Sources/Tensors/Matrix/MatrixFlatView.swift
+++ b/Sources/Tensors/Matrix/MatrixFlatView.swift
@@ -22,6 +22,11 @@ public struct MatrixFlatView<Scalar: PluScalar>: MatrixView, Equatable {
         let elements = (0..<columns).flatMap { column in (0..<rows).map { row in values[row][column] } }
         self.init(view: TensorFlatView(shape: [rows, columns], elements: elements))
     }
+
+    public init(_ values: TensorNestedArray<Scalar>) {
+        precondition(values.shape.count == 2, "Matrix nested array must have rank 2")
+        self.init(view: TensorFlatView(values))
+    }
     
     public subscript(_ indices: [Int]) -> Scalar {
         get {

--- a/Sources/Tensors/Protocols/TensorIndex.swift
+++ b/Sources/Tensors/Protocols/TensorIndex.swift
@@ -1,0 +1,85 @@
+public struct TensorIndex: Hashable, ExpressibleByStringLiteral {
+    public let symbol: String
+
+    public init(_ symbol: String) {
+        precondition(!symbol.isEmpty, "Tensor index symbol must not be empty"); self.symbol = symbol
+    }
+    public init(stringLiteral value: String) { self.init(value) }
+}
+
+public func multiply<L: TensorMultiplication, R: TensorMultiplication>(
+    _ left: L,
+    _ leftIndices: [TensorIndex],
+    _ right: R,
+    _ rightIndices: [TensorIndex]
+) -> L where L.S == R.S {
+    precondition(leftIndices.count == left.rank, "Left index count must match tensor rank")
+    precondition(rightIndices.count == right.rank, "Right index count must match tensor rank")
+    precondition(Set(leftIndices).count == leftIndices.count, "Left indices must not repeat")
+    precondition(Set(rightIndices).count == rightIndices.count, "Right indices must not repeat")
+    let rightAxisByIndex = Dictionary(uniqueKeysWithValues: rightIndices.enumerated().map { ($0.element, $0.offset) })
+    let axes = leftIndices.enumerated().compactMap { leftAxis, index -> (left: Int, right: Int)? in
+        guard let rightAxis = rightAxisByIndex[index] else { return nil }
+        return (leftAxis, rightAxis)
+    }
+    return left.times(right, contract: axes)
+}
+
+public func multiply<L: TensorMultiplication, R: TensorMultiplication>(
+    _ left: L,
+    _ right: R,
+    _ notation: String
+) -> L where L.S == R.S {
+    let compact = notation.filter { !$0.isWhitespace }
+    precondition(!compact.contains("->"), "Tensor multiplication notation must not include an output clause")
+    let operands = compact.split(separator: ",", omittingEmptySubsequences: false)
+    precondition(operands.count == 2, "Tensor multiplication notation must contain two operands")
+    return multiply(left, tensorIndices(operands[0]), right, tensorIndices(operands[1]))
+}
+
+private func tensorIndices(_ symbols: Substring) -> [TensorIndex] { symbols.map { TensorIndex(String($0)) } }
+
+public func permute<T: TensorMultiplication>(
+    _ tensor: T,
+    from sourceIndices: [TensorIndex],
+    to destinationIndices: [TensorIndex]
+) -> T {
+    precondition(sourceIndices.count == tensor.rank, "Source index count must match tensor rank")
+    precondition(destinationIndices.count == tensor.rank, "Destination index count must match tensor rank")
+    precondition(Set(sourceIndices).count == sourceIndices.count, "Source indices must not repeat")
+    precondition(Set(destinationIndices) == Set(sourceIndices), "Destination indices must permute source indices")
+    let sourceAxisByIndex = Dictionary(uniqueKeysWithValues: sourceIndices.enumerated().map { ($0.element, $0.offset) })
+    let sourceAxes = destinationIndices.map { sourceAxisByIndex[$0]! }
+    let resultShape = sourceAxes.map { tensor.shape[$0] }
+    var result = T(shape: resultShape, initialValue: .zero)
+    for resultIndex in indexCombinations(for: resultShape) {
+        var sourceIndex = Array(repeating: 0, count: tensor.rank)
+        for (resultAxis, sourceAxis) in sourceAxes.enumerated() { sourceIndex[sourceAxis] = resultIndex[resultAxis] }
+        result[resultIndex] = tensor[sourceIndex]
+    }
+    return result
+}
+
+public func permute<T: TensorMultiplication>(_ tensor: T, _ notation: String) -> T {
+    let compact = notation.filter { !$0.isWhitespace }
+    guard let arrow = compact.range(of: "->") else {
+        preconditionFailure("Tensor permutation notation must contain an output clause")
+    }
+    let source = compact[..<arrow.lowerBound]
+    let destination = compact[arrow.upperBound...]
+    precondition(!destination.contains("->"), "Tensor permutation notation must contain one output clause")
+    return permute(tensor, from: tensorIndices(source), to: tensorIndices(destination))
+}
+
+private func indexCombinations(for shape: [Int]) -> [[Int]] {
+    if shape.isEmpty { return [[]] }
+    if shape.contains(0) { return [] }
+    return (0..<shape.reduce(1, *)).map { flatIndex in
+        var remaining = flatIndex
+        return shape.map { dimension in
+            let index = remaining % dimension
+            remaining /= dimension
+            return index
+        }
+    }
+}

--- a/Sources/Tensors/Protocols/TensorMultiplication.swift
+++ b/Sources/Tensors/Protocols/TensorMultiplication.swift
@@ -1,5 +1,4 @@
 public protocol TensorMultiplication: TensorStructure {
-    associatedtype S: PluScalar
     associatedtype MatrixImplementation: PluMatrix where MatrixImplementation.S == S
 
     init(shape: [Int], initialValue: S)

--- a/Sources/Tensors/Protocols/TensorStructure.swift
+++ b/Sources/Tensors/Protocols/TensorStructure.swift
@@ -1,4 +1,73 @@
+public enum TensorNestedArray<S: PluScalar>: Equatable {
+    case scalar(S)
+    indirect case array([TensorNestedArray<S>])
+
+    public var shape: [Int] {
+        switch self {
+        case .scalar:
+            return []
+        case .array(let children):
+            precondition(!children.isEmpty, "Cannot infer tensor shape from an empty nested array")
+            let childShape = children[0].shape
+            precondition(children.allSatisfy { $0.shape == childShape }, "Tensor nested arrays must be rectangular")
+            return [children.count] + childShape
+        }
+    }
+
+    public subscript(_ indices: [Int]) -> S {
+        switch (self, indices.first) {
+        case (.scalar(let value), nil):
+            return value
+        case (.array(let children), .some(let index)):
+            precondition(index >= 0 && index < children.count, "Tensor index out of bounds")
+            return children[index][Array(indices.dropFirst())]
+        default:
+            preconditionFailure("Tensor index rank must match tensor rank")
+        }
+    }
+
+    public func columnMajorElements() -> [S] {
+        Self.indexCombinations(for: shape).map { self[$0] }
+    }
+
+    private static func indexCombinations(for shape: [Int]) -> [[Int]] {
+        if shape.isEmpty { return [[]] }
+        if shape.contains(0) { return [] }
+        return (0..<shape.reduce(1, *)).map { flatIndex in
+            var remaining = flatIndex
+            return shape.map { dimension in
+                let index = remaining % dimension
+                remaining /= dimension
+                return index
+            }
+        }
+    }
+}
+
+extension TensorNestedArray: ExpressibleByArrayLiteral {
+    public typealias ArrayLiteralElement = TensorNestedArray<S>
+    public init(arrayLiteral elements: TensorNestedArray<S>...) {
+        self = .array(elements)
+    }
+}
+
+extension TensorNestedArray: ExpressibleByIntegerLiteral where S: ExpressibleByIntegerLiteral {
+    public typealias IntegerLiteralType = S.IntegerLiteralType
+    public init(integerLiteral value: S.IntegerLiteralType) {
+        self = .scalar(S(integerLiteral: value))
+    }
+}
+
+extension TensorNestedArray: ExpressibleByFloatLiteral where S: ExpressibleByFloatLiteral {
+    public typealias FloatLiteralType = S.FloatLiteralType
+    public init(floatLiteral value: S.FloatLiteralType) {
+        self = .scalar(S(floatLiteral: value))
+    }
+}
+
 public protocol TensorStructure {
+    associatedtype S: PluScalar
     var shape: [Int] { get }
     var rank: Int { get }
+    init(_ values: TensorNestedArray<S>)
 }

--- a/Sources/Tensors/Storage/TensorFlatView.swift
+++ b/Sources/Tensors/Storage/TensorFlatView.swift
@@ -24,6 +24,10 @@ public struct TensorFlatView<Scalar: PluScalar>: TensorView, Equatable {
         let strides = Self.columnMajorStrides(for: shape)
         self.init(storage: TensorStorage(elements), offset: 0, shape: shape, strides: strides)
     }
+
+    public init(_ values: TensorNestedArray<Scalar>) {
+        self.init(shape: values.shape, elements: values.columnMajorElements())
+    }
     
     public init(storage: TensorStorage<Scalar>, offset: Int, shape: [Int], strides: [Int]) {
         precondition(offset >= 0, "Tensor view offset must be non-negative")

--- a/Sources/Tensors/Storage/TensorView.swift
+++ b/Sources/Tensors/Storage/TensorView.swift
@@ -1,4 +1,4 @@
-public protocol TensorView: TensorStructure {
+public protocol TensorView: TensorStructure where S == Scalar {
     associatedtype Scalar: PluScalar
     
     var elements: [Scalar] { get }

--- a/Sources/Tensors/Tensor/TensorDenseBLAS.swift
+++ b/Sources/Tensors/Tensor/TensorDenseBLAS.swift
@@ -18,6 +18,10 @@ public struct TensorDenseBLAS<S: PluScalar>: TensorMultiplication, TensorArithme
         self.view = TensorFlatView(shape: shape, elements: elements)
     }
 
+    public init(_ values: TensorNestedArray<S>) {
+        self.init(shape: values.shape, elements: values.columnMajorElements())
+    }
+
     public subscript(_ indices: [Int]) -> S {
         get { view[indices] }
         set { view[indices] = newValue }

--- a/Sources/Tensors/Tensor/TensorDenseReference.swift
+++ b/Sources/Tensors/Tensor/TensorDenseReference.swift
@@ -1,4 +1,7 @@
-public struct TensorDenseReference<S: PluScalar>: PluTensor, TensorStructure, TensorArithmeticReference {
+public struct TensorDenseReference<S: PluScalar>: PluTensor, TensorStructure, TensorMultiplication,
+    TensorArithmeticReference {
+    public typealias MatrixImplementation = MatrixDenseReference<S>
+
     private var storage: TensorNestedArray<S>
 
     public let shape: [Int]

--- a/Sources/Tensors/Tensor/TensorDenseReference.swift
+++ b/Sources/Tensors/Tensor/TensorDenseReference.swift
@@ -1,32 +1,3 @@
-public indirect enum TensorNestedArray<S: PluScalar>: Equatable {
-    case scalar(S)
-    case array([TensorNestedArray<S>])
-}
-
-extension TensorNestedArray: ExpressibleByArrayLiteral {
-    public typealias ArrayLiteralElement = TensorNestedArray<S>
-
-    public init(arrayLiteral elements: TensorNestedArray<S>...) {
-        self = .array(elements)
-    }
-}
-
-extension TensorNestedArray: ExpressibleByIntegerLiteral where S: ExpressibleByIntegerLiteral {
-    public typealias IntegerLiteralType = S.IntegerLiteralType
-
-    public init(integerLiteral value: S.IntegerLiteralType) {
-        self = .scalar(S(integerLiteral: value))
-    }
-}
-
-extension TensorNestedArray: ExpressibleByFloatLiteral where S: ExpressibleByFloatLiteral {
-    public typealias FloatLiteralType = S.FloatLiteralType
-
-    public init(floatLiteral value: S.FloatLiteralType) {
-        self = .scalar(S(floatLiteral: value))
-    }
-}
-
 public struct TensorDenseReference<S: PluScalar>: PluTensor, TensorStructure, TensorArithmeticReference {
     private var storage: TensorNestedArray<S>
 
@@ -34,7 +5,7 @@ public struct TensorDenseReference<S: PluScalar>: PluTensor, TensorStructure, Te
     public var rank: Int { shape.count }
 
     public init(_ values: TensorNestedArray<S>) {
-        self.shape = Self.shape(of: values)
+        self.shape = values.shape
         self.storage = values
     }
 
@@ -61,21 +32,6 @@ public struct TensorDenseReference<S: PluScalar>: PluTensor, TensorStructure, Te
     }
 
     public func toNestedArray() -> TensorNestedArray<S> { storage }
-
-    private static func shape(of storage: TensorNestedArray<S>) -> [Int] {
-        switch storage {
-        case .scalar:
-            return []
-        case .array(let children):
-            precondition(!children.isEmpty, "Cannot infer tensor shape from an empty nested array")
-            let childShape = shape(of: children[0])
-            precondition(
-                children.allSatisfy { shape(of: $0) == childShape },
-                "Tensor nested arrays must be rectangular"
-            )
-            return [children.count] + childShape
-        }
-    }
 
     private static func storage(shape: [Int], initialValue: S) -> TensorNestedArray<S> {
         guard let size = shape.first else { return .scalar(initialValue) }

--- a/Sources/Tensors/TensorBases.swift
+++ b/Sources/Tensors/TensorBases.swift
@@ -24,6 +24,10 @@ public struct VectorBase<Implementation: PluVector>: PluVector, TensorArithmetic
         self.implementation = Implementation(elements)
     }
 
+    public init(_ values: TensorNestedArray<Implementation.S>) {
+        self.implementation = Implementation(values)
+    }
+
     public init(shape: [Int], initialValue: Implementation.S) {
         precondition(shape.count == 1, "Vector shape must have rank 1")
         precondition(shape[0] >= 0, "Vector size must be non-negative")
@@ -73,6 +77,10 @@ public struct MatrixBase<Implementation: PluMatrix>: PluMatrix, TensorArithmetic
     }
 
     public init(_ values: [[Implementation.S]]) {
+        self.implementation = Implementation(values)
+    }
+
+    public init(_ values: TensorNestedArray<Implementation.S>) {
         self.implementation = Implementation(values)
     }
 

--- a/Sources/Tensors/Vector/VectorDenseBLAS.swift
+++ b/Sources/Tensors/Vector/VectorDenseBLAS.swift
@@ -22,6 +22,11 @@ public struct VectorDenseBLAS<S: PluScalar>: PluVector, TensorArithmeticBLAS {
         self.elements = values
     }
 
+    public init(_ values: TensorNestedArray<S>) {
+        precondition(values.shape.count == 1, "Vector nested array must have rank 1")
+        self.init(values.columnMajorElements())
+    }
+
     public func toArray(round: Bool) -> [S] {
         if round {
             return elements.map { $0.round() }

--- a/Sources/Tensors/Vector/VectorDenseReference.swift
+++ b/Sources/Tensors/Vector/VectorDenseReference.swift
@@ -22,6 +22,11 @@ public struct VectorDenseReference<S: PluScalar>: PluVector, TensorArithmeticRef
     public init(_ values: [S]) {
         self.elements = values
     }
+
+    public init(_ values: TensorNestedArray<S>) {
+        precondition(values.shape.count == 1, "Vector nested array must have rank 1")
+        self.init(values.columnMajorElements())
+    }
     
     public func toArray(round: Bool) -> [S] {
         if round {

--- a/Sources/Tensors/Vector/VectorFlatView.swift
+++ b/Sources/Tensors/Vector/VectorFlatView.swift
@@ -18,6 +18,11 @@ public struct VectorFlatView<Scalar: PluScalar>: VectorView, Equatable {
     public init(_ elements: [Scalar]) {
         self.init(view: TensorFlatView(shape: [elements.count], elements: elements))
     }
+
+    public init(_ values: TensorNestedArray<Scalar>) {
+        precondition(values.shape.count == 1, "Vector nested array must have rank 1")
+        self.init(values.columnMajorElements())
+    }
     
     public subscript(_ indices: [Int]) -> Scalar {
         get {

--- a/Tests/TensorsTests/MatrixDenseTests.swift
+++ b/Tests/TensorsTests/MatrixDenseTests.swift
@@ -26,6 +26,13 @@ enum MatrixImplementation: CaseIterable, CustomStringConvertible {
         }
     }
 
+    func checkNestedArrayInitializer() {
+        switch self {
+        case .reference: verifyNestedArrayInitializer(MatrixDenseReference<Double>.self)
+        case .blas: verifyNestedArrayInitializer(MatrixDenseBLAS<Double>.self)
+        }
+    }
+
     func checkVectorMultiplication() {
         switch self {
         case .reference: verifyVectorMultiplication(MatrixDenseReference<Double>.self)
@@ -108,6 +115,11 @@ func MatrixDense_initializerWithRowsAndColumns(implementation: MatrixImplementat
 }
 
 @Test(arguments: MatrixImplementation.allCases)
+func MatrixDense_nestedArrayInitializer(implementation: MatrixImplementation) {
+    implementation.checkNestedArrayInitializer()
+}
+
+@Test(arguments: MatrixImplementation.allCases)
 func MatrixDense_vectorMultiplication(implementation: MatrixImplementation) {
     implementation.checkVectorMultiplication()
 }
@@ -178,6 +190,15 @@ private func verifyInitializerWithRowsAndColumns<M: PluMatrix>(_ type: M.Type) w
     }
     matrix[1, 2] = 3.14
     #expect(matrix[1, 2] == 3.14)
+}
+
+private func verifyNestedArrayInitializer<M: PluMatrix>(_ type: M.Type) where M.S == Double {
+    let values: TensorNestedArray<Double> = [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]
+    let matrix = M(values)
+
+    #expect(matrix.shape == [2, 3])
+    #expect(matrix.rank == 2)
+    #expect(matrix.toArray() == [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
 }
 
 private func verifyVectorMultiplication<M: PluMatrix>(_ type: M.Type) where M.S == Double {

--- a/Tests/TensorsTests/ScalarTests.swift
+++ b/Tests/TensorsTests/ScalarTests.swift
@@ -37,9 +37,17 @@ import Testing
 @Test func Complex_plumeriaScalarProperties() {
     let z = Complex(3.0, 4.0)
 
+    #expect(Complex.i == Complex(0.0, 1.0))
     #expect(z.star == Complex(3.0, -4.0))
     #expect(z.mod == 5.0)
     #expect(z.arg.isApproximatelyEqual(to: 0.9272952180016122, relativeTolerance: 1e-15))
+}
+
+@Test func Complex_imaginaryUnitSupportsLocalMathNotation() {
+    let i = Complex.i
+    let z = 1.2 + 3.4 * i
+
+    #expect(z == Complex(1.2, 3.4))
 }
 
 @Test func PluScalar_roundsWithPrecision() {

--- a/Tests/TensorsTests/TensorDenseTests.swift
+++ b/Tests/TensorsTests/TensorDenseTests.swift
@@ -34,6 +34,13 @@ enum TensorImplementation: CaseIterable, CustomStringConvertible {
         }
     }
 
+    func checkNestedArrayInitializer() {
+        switch self {
+        case .reference: verifyNestedArrayInitializer(TensorDenseReference<Double>.self)
+        case .blas: verifyNestedArrayInitializer(TensorDenseBLAS<Double>.self)
+        }
+    }
+
     func checkRankZeroTensors() {
         switch self {
         case .reference: verifyRankZeroTensors(TensorDenseReference<Double>.self)
@@ -60,9 +67,12 @@ func TensorDense_readsAndMutatesElements(implementation: TensorImplementation) {
 }
 
 @Test(arguments: TensorImplementation.allCases)
-func TensorDense_supportsRankZeroTensors(implementation: TensorImplementation) {
-    implementation.checkRankZeroTensors()
+func TensorDense_nestedArrayInitializer(implementation: TensorImplementation) {
+    implementation.checkNestedArrayInitializer()
 }
+
+@Test(arguments: TensorImplementation.allCases)
+func TensorDense_supportsRankZeroTensors(implementation: TensorImplementation) { implementation.checkRankZeroTensors() }
 
 @Test(arguments: TensorImplementation.allCases)
 func TensorDense_elementwiseArithmetic(implementation: TensorImplementation) {
@@ -71,7 +81,6 @@ func TensorDense_elementwiseArithmetic(implementation: TensorImplementation) {
 
 private func verifyInitializesWithValue<T: TensorDenseTestImplementation>(_ type: T.Type) {
     let tensor = T(shape: [2, 3], initialValue: 2.0)
-
     #expect(tensor.shape == [2, 3])
     #expect(tensor.rank == 2)
     #expect(tensor[[0, 0]] == 2.0)
@@ -89,13 +98,26 @@ private func verifyReadsAndMutatesElements<T: TensorDenseTestImplementation>(_ t
     #expect(tensor[[0, 2]] == 3.0)
 }
 
+private func verifyNestedArrayInitializer<T: TensorDenseTestImplementation>(_ type: T.Type) {
+    let values: TensorNestedArray<Double> = [
+        [[1.0, -1.0], [2.0, 0.0]],
+        [[0.0, 2.0], [-2.0, 1.0]],
+        [[3.0, 1.0], [1.0, -3.0]]
+    ]
+    let tensor = T(values)
+
+    #expect(tensor.shape == [3, 2, 2])
+    #expect(tensor.rank == 3)
+    #expect(tensor[[0, 0, 0]] == 1.0)
+    #expect(tensor[[1, 1, 0]] == -2.0)
+    #expect(tensor[[2, 1, 1]] == -3.0)
+}
+
 private func verifyRankZeroTensors<T: TensorDenseTestImplementation>(_ type: T.Type) {
     var tensor = T(shape: [], initialValue: 7.0)
-
     #expect(tensor.shape == [])
     #expect(tensor.rank == 0)
     #expect(tensor[[]] == 7.0)
-
     tensor[[]] = -2.0
     #expect(tensor[[]] == -2.0)
 }

--- a/Tests/TensorsTests/TensorDenseTests.swift
+++ b/Tests/TensorsTests/TensorDenseTests.swift
@@ -1,9 +1,8 @@
 import Testing
 @testable import Tensors
 
-protocol TensorDenseTestImplementation: TensorArithmetic, TensorStructure where S == Double, Magnitude == Double {
+protocol TensorDenseTestImplementation: TensorArithmetic, TensorMultiplication where S == Double, Magnitude == Double {
     init(shape: [Int], initialValue: Double)
-    subscript(_ indices: [Int]) -> Double { get set }
 }
 
 extension TensorDenseReference: TensorDenseTestImplementation where S == Double {}
@@ -54,6 +53,27 @@ enum TensorImplementation: CaseIterable, CustomStringConvertible {
         case .blas: verifyElementwiseArithmetic(TensorDenseBLAS<Double>.self)
         }
     }
+
+    func checkIndexMultiply() {
+        switch self {
+        case .reference: verifyIndexMultiply(TensorDenseReference<Double>.self)
+        case .blas: verifyIndexMultiply(TensorDenseBLAS<Double>.self)
+        }
+    }
+
+    func checkStringMultiply() {
+        switch self {
+        case .reference: verifyStringMultiply(TensorDenseReference<Double>.self)
+        case .blas: verifyStringMultiply(TensorDenseBLAS<Double>.self)
+        }
+    }
+
+    func checkPermute() {
+        switch self {
+        case .reference: verifyPermute(TensorDenseReference<Double>.self)
+        case .blas: verifyPermute(TensorDenseBLAS<Double>.self)
+        }
+    }
 }
 
 @Test(arguments: TensorImplementation.allCases)
@@ -77,6 +97,21 @@ func TensorDense_supportsRankZeroTensors(implementation: TensorImplementation) {
 @Test(arguments: TensorImplementation.allCases)
 func TensorDense_elementwiseArithmetic(implementation: TensorImplementation) {
     implementation.checkElementwiseArithmetic()
+}
+
+@Test(arguments: TensorImplementation.allCases)
+func TensorDense_indexMultiply(implementation: TensorImplementation) {
+    implementation.checkIndexMultiply()
+}
+
+@Test(arguments: TensorImplementation.allCases)
+func TensorDense_stringMultiply(implementation: TensorImplementation) {
+    implementation.checkStringMultiply()
+}
+
+@Test(arguments: TensorImplementation.allCases)
+func TensorDense_permute(implementation: TensorImplementation) {
+    implementation.checkPermute()
 }
 
 private func verifyInitializesWithValue<T: TensorDenseTestImplementation>(_ type: T.Type) {
@@ -144,6 +179,61 @@ private func verifyElementwiseArithmetic<T: TensorDenseTestImplementation>(_ typ
     #expect(scaledLeft == scaledRight)
     #expect(divided[[0, 0, 1]] == -0.5)
     #expect(sum.isApproximatelyEqual(to: sum, relativeTolerance: 1e-12, norm: { _ in 0.0 }))
+}
+
+private func verifyIndexMultiply<T: TensorDenseTestImplementation>(_ type: T.Type) {
+    let i = TensorIndex("i"), j = TensorIndex("j"), k = TensorIndex("k")
+    let leftValues: TensorNestedArray<Double> = [
+        [1.0, 2.0, 0.0],
+        [-1.0, 3.0, 1.0]
+    ]
+    let rightValues: TensorNestedArray<Double> = [
+        [2.0, 1.0],
+        [0.0, -1.0],
+        [3.0, 2.0]
+    ]
+    let product = multiply(T(leftValues), [i, j], T(rightValues), [j, k])
+
+    #expect(product.shape == [2, 2])
+    #expect(product[[0, 0]] == 2.0)
+    #expect(product[[1, 0]] == 1.0)
+    #expect(product[[0, 1]] == -1.0)
+    #expect(product[[1, 1]] == -2.0)
+}
+
+private func verifyPermute<T: TensorDenseTestImplementation>(_ type: T.Type) {
+    let i = TensorIndex("i"), j = TensorIndex("j"), k = TensorIndex("k")
+    let values: TensorNestedArray<Double> = [
+        [[1.0, -1.0], [2.0, 0.0], [3.0, 1.0]],
+        [[0.0, 2.0], [-2.0, 1.0], [1.0, -3.0]]
+    ]
+    let indexed = permute(T(values), from: [i, j, k], to: [j, i, k])
+    let string = permute(T(values), "ijk -> jik")
+
+    #expect(indexed.shape == [3, 2, 2])
+    #expect(string.shape == indexed.shape)
+    #expect(indexed[[1, 0, 0]] == 2.0)
+    #expect(indexed[[2, 1, 1]] == -3.0)
+    #expect(string == indexed)
+}
+
+private func verifyStringMultiply<T: TensorDenseTestImplementation>(_ type: T.Type) {
+    let leftValues: TensorNestedArray<Double> = [
+        [1.0, 2.0, 0.0],
+        [-1.0, 3.0, 1.0]
+    ]
+    let rightValues: TensorNestedArray<Double> = [
+        [2.0, 1.0],
+        [0.0, -1.0],
+        [3.0, 2.0]
+    ]
+    let product = multiply(T(leftValues), T(rightValues), "ij, jk")
+
+    #expect(product.shape == [2, 2])
+    #expect(product[[0, 0]] == 2.0)
+    #expect(product[[1, 0]] == 1.0)
+    #expect(product[[0, 1]] == -1.0)
+    #expect(product[[1, 1]] == -2.0)
 }
 
 private func rank3Tensor<T: TensorDenseTestImplementation>(_ type: T.Type, values: [[[Double]]]) -> T {

--- a/Tests/TensorsTests/TensorDenseTests.swift
+++ b/Tests/TensorsTests/TensorDenseTests.swift
@@ -68,6 +68,13 @@ enum TensorImplementation: CaseIterable, CustomStringConvertible {
         }
     }
 
+    func checkOuterMultiply() {
+        switch self {
+        case .reference: verifyOuterMultiply(TensorDenseReference<Double>.self)
+        case .blas: verifyOuterMultiply(TensorDenseBLAS<Double>.self)
+        }
+    }
+
     func checkPermute() {
         switch self {
         case .reference: verifyPermute(TensorDenseReference<Double>.self)
@@ -107,6 +114,11 @@ func TensorDense_indexMultiply(implementation: TensorImplementation) {
 @Test(arguments: TensorImplementation.allCases)
 func TensorDense_stringMultiply(implementation: TensorImplementation) {
     implementation.checkStringMultiply()
+}
+
+@Test(arguments: TensorImplementation.allCases)
+func TensorDense_outerMultiply(implementation: TensorImplementation) {
+    implementation.checkOuterMultiply()
 }
 
 @Test(arguments: TensorImplementation.allCases)
@@ -234,6 +246,21 @@ private func verifyStringMultiply<T: TensorDenseTestImplementation>(_ type: T.Ty
     #expect(product[[1, 0]] == 1.0)
     #expect(product[[0, 1]] == -1.0)
     #expect(product[[1, 1]] == -2.0)
+}
+
+private func verifyOuterMultiply<T: TensorDenseTestImplementation>(_ type: T.Type) {
+    let i = TensorIndex("i"), j = TensorIndex("j"), k = TensorIndex("k"), l = TensorIndex("l")
+    let leftValues: TensorNestedArray<Double> = [[1.0, 2.0], [-1.0, 0.0]]
+    let rightValues: TensorNestedArray<Double> = [[2.0, 1.0], [0.0, -1.0], [3.0, 2.0]]
+    let indexed = multiply(T(leftValues), [i, j], T(rightValues), [k, l])
+    let string = multiply(T(leftValues), T(rightValues), "ij, kl")
+
+    #expect(indexed.shape == [2, 2, 3, 2])
+    #expect(string.shape == indexed.shape)
+    #expect(indexed[[0, 0, 0, 0]] == 2.0)
+    #expect(indexed[[1, 0, 2, 1]] == -2.0)
+    #expect(indexed[[0, 1, 1, 1]] == -2.0)
+    #expect(string == indexed)
 }
 
 private func rank3Tensor<T: TensorDenseTestImplementation>(_ type: T.Type, values: [[[Double]]]) -> T {

--- a/Tests/TensorsTests/TensorMultiplicationTests.swift
+++ b/Tests/TensorsTests/TensorMultiplicationTests.swift
@@ -18,6 +18,11 @@ private struct TestTensor<S: PluScalar>: TensorMultiplication {
         self.elements = elements
     }
 
+    init(_ values: TensorNestedArray<S>) {
+        self.shape = values.shape
+        self.elements = values.columnMajorElements()
+    }
+
     subscript(_ indices: [Int]) -> S {
         get { elements[Self.linearIndex(indices, shape: shape)] }
         set { elements[Self.linearIndex(indices, shape: shape)] = newValue }

--- a/Tests/TensorsTests/VectorTests.swift
+++ b/Tests/TensorsTests/VectorTests.swift
@@ -29,6 +29,13 @@ enum VectorImplementation: CaseIterable, CustomStringConvertible {
         }
     }
 
+    func checkNestedArrayInitializer() {
+        switch self {
+        case .reference: verifyNestedArrayInitializer(VectorDenseReference<Double>.self)
+        case .blas: verifyNestedArrayInitializer(VectorDenseBLAS<Double>.self)
+        }
+    }
+
     func checkPhysicsOperations() {
         switch self {
         case .reference: verifyPhysicsOperations(VectorDenseReference<Double>.self)
@@ -66,39 +73,30 @@ enum VectorImplementation: CaseIterable, CustomStringConvertible {
 }
 
 @Test(arguments: VectorImplementation.allCases)
-func VectorDense_initDouble(implementation: VectorImplementation) {
-    implementation.checkDoubleInit()
+func VectorDense_initDouble(implementation: VectorImplementation) { implementation.checkDoubleInit() }
+
+@Test(arguments: VectorImplementation.allCases)
+func VectorDense_initComplex(implementation: VectorImplementation) { implementation.checkComplexInit() }
+
+@Test(arguments: VectorImplementation.allCases)
+func VectorDense_nestedArrayInitializer(implementation: VectorImplementation) {
+    implementation.checkNestedArrayInitializer()
 }
 
 @Test(arguments: VectorImplementation.allCases)
-func VectorDense_initComplex(implementation: VectorImplementation) {
-    implementation.checkComplexInit()
-}
+func VectorDense_physicsOperations(implementation: VectorImplementation) { implementation.checkPhysicsOperations() }
 
 @Test(arguments: VectorImplementation.allCases)
-func VectorDense_physicsOperations(implementation: VectorImplementation) {
-    implementation.checkPhysicsOperations()
-}
+func VectorDense_arithmetic(implementation: VectorImplementation) { implementation.checkArithmetic() }
 
 @Test(arguments: VectorImplementation.allCases)
-func VectorDense_arithmetic(implementation: VectorImplementation) {
-    implementation.checkArithmetic()
-}
+func VectorDense_complexArithmetic(implementation: VectorImplementation) { implementation.checkComplexArithmetic() }
 
 @Test(arguments: VectorImplementation.allCases)
-func VectorDense_complexArithmetic(implementation: VectorImplementation) {
-    implementation.checkComplexArithmetic()
-}
+func VectorDense_toArray(implementation: VectorImplementation) { implementation.checkToArray() }
 
 @Test(arguments: VectorImplementation.allCases)
-func VectorDense_toArray(implementation: VectorImplementation) {
-    implementation.checkToArray()
-}
-
-@Test(arguments: VectorImplementation.allCases)
-func VectorDense_tensorStructure(implementation: VectorImplementation) {
-    implementation.checkTensorStructure()
-}
+func VectorDense_tensorStructure(implementation: VectorImplementation) { implementation.checkTensorStructure() }
 
 @Test func DefaultVector_aliasUsesRecommendedImplementation() {
     let vector = Vector<Double>([1.0, 2.0, 3.0])
@@ -125,6 +123,14 @@ private func verifyComplexInit<V: PluVector>(_ type: V.Type) where V.S == Comple
     #expect(v[1].real == b[0])
     #expect(v[1].imaginary == b[1])
     #expect(v[1] == Complex(b[0], b[1]))
+}
+
+private func verifyNestedArrayInitializer<V: PluVector>(_ type: V.Type) where V.S == Double {
+    let values: TensorNestedArray<Double> = [1.0, -2.0, 3.0]
+    let vector = V(values)
+    #expect(vector.shape == [3])
+    #expect(vector.rank == 1)
+    #expect(vector.toArray() == [1.0, -2.0, 3.0])
 }
 
 private func verifyPhysicsOperations<V: PluVector>(_ type: V.Type) where V.S == Double {


### PR DESCRIPTION
## Changes

- Added `Complex.i` for local math-style complex notation.
- Added shared nested-array initialization through `TensorNestedArray` and `TensorStructure`.
- Added nested-array initializers for dense tensor, matrix, vector, and flat-view implementations.
- Added `TensorIndex` plus non-string tensor `multiply` and `permute` conveniences.
- Added string shorthand for tensor `multiply` and `permute`, with tensor arguments before notation strings.
- Made `TensorDenseReference` support tensor multiplication.
- Added parameterized reference/BLAS tests for nested-array initialization, index/string multiplication, outer products, and permutation.