### PR TITLE
Create release 0.1.0

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,20 +2,88 @@ name: Plumeria Mathematics Release
 
 on:
   push:
-    tags:
-      - '*'
+    tags: ["*"]
+
+permissions:
+  contents: write
 
 jobs:
-  release:
+  create-release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - name: Create Release
-        uses: actions/create-release@v1
+      - name: Create release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref_name }}
-          release_name: Release ${{ github.ref_name }}
-          draft: false
-          prerelease: true
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release view "${{ github.ref_name }}" --repo "${{ github.repository }}" || \
+            gh release create "${{ github.ref_name }}" --repo "${{ github.repository }}" \
+              --title "Release ${{ github.ref_name }}" \
+              --notes "Plumeria Mathematics ${{ github.ref_name }}"
+
+  build-darwin-m1:
+    needs: create-release
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build artifact
+        run: |
+          ./BuildScripts/install-pluscilib-darwin-m1.sh
+          swift build -c release --product PlumeriaMathematics
+          ./BuildScripts/package-release-artifact.sh "${{ github.ref_name }}" darwin-m1
+      - name: Upload artifact
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release upload "${{ github.ref_name }}" dist/*.tar.gz dist/*.sha256 \
+            --clobber --repo "${{ github.repository }}"
+
+  build-linux-aarch64:
+    needs: create-release
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build artifact
+        run: |
+          ./BuildScripts/install-pluscilib-linux-aarch64.sh
+          swift build -c release --product PlumeriaMathematics
+          ./BuildScripts/package-release-artifact.sh "${{ github.ref_name }}" linux-aarch64
+      - name: Upload artifact
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release upload "${{ github.ref_name }}" dist/*.tar.gz dist/*.sha256 \
+            --clobber --repo "${{ github.repository }}"
+
+  build-linux-neoverse-v2:
+    needs: create-release
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build artifact
+        run: |
+          ./BuildScripts/install-pluscilib-linux-neoverse_v2.sh
+          swift build -c release --product PlumeriaMathematics
+          ./BuildScripts/package-release-artifact.sh "${{ github.ref_name }}" linux-neoverse_v2
+      - name: Upload artifact
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release upload "${{ github.ref_name }}" dist/*.tar.gz dist/*.sha256 \
+            --clobber --repo "${{ github.repository }}"
+
+  build-linux-x86-64:
+    needs: create-release
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build artifact
+        run: |
+          ./BuildScripts/install-pluscilib-linux-x86_64.sh
+          swift build -c release --product PlumeriaMathematics
+          ./BuildScripts/package-release-artifact.sh "${{ github.ref_name }}" linux-x86_64
+      - name: Upload artifact
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release upload "${{ github.ref_name }}" dist/*.tar.gz dist/*.sha256 \
+            --clobber --repo "${{ github.repository }}"

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 .build/
 .swiftpm/
+dist/

--- a/BuildScripts/package-release-artifact.sh
+++ b/BuildScripts/package-release-artifact.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -euo pipefail
+
+version="$1"
+platform="$2"
+release_dir="$(swift build -c release --show-bin-path)"
+artifact="plumeria-mathematics-${version}-${platform}"
+staging="dist/${artifact}"
+
+rm -rf "$staging" "${staging}.tar.gz" "${staging}.sha256"
+mkdir -p "$staging/lib" "$staging/Modules" "$staging/include" "$staging/metadata"
+find "$release_dir" -maxdepth 1 -type f -name 'libPlumeriaMathematics.*' -exec cp {} "$staging/lib/" \;
+find "$release_dir" -maxdepth 1 -type d -name 'libPlumeriaMathematics.*.dSYM' -exec cp -R {} "$staging/lib/" \;
+test -n "$(find "$staging/lib" -maxdepth 1 -type f -name 'libPlumeriaMathematics.*' -print -quit)"
+cp "$release_dir"/Modules/*.{swiftmodule,swiftdoc,swiftsourceinfo} "$staging/Modules/" 2>/dev/null || true
+find "$release_dir" -path '*/include/*' -type f -exec cp {} "$staging/include/" \;
+swift --version > "$staging/metadata/swift-version.txt"
+uname -a > "$staging/metadata/uname.txt"
+printf '%s\n' "$version" > "$staging/metadata/version.txt"
+printf '%s\n' "$platform" > "$staging/metadata/platform.txt"
+tar -czf "${staging}.tar.gz" -C dist "$artifact"
+shasum -a 256 "${staging}.tar.gz" > "${staging}.sha256"

--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ import PackageDescription
 let package = Package(
     name: "PlumeriaMathematics",
     platforms: [.macOS(.v15)],
-    products: [.library(name: "PlumeriaMathematics", targets: ["PlumeriaMathematics"])],
+    products: [.library(name: "PlumeriaMathematics", type: .dynamic, targets: ["PlumeriaMathematics"])],
     dependencies: [.package(url: "https://github.com/apple/swift-numerics", from: "1.0.0")],
     targets: [
         .systemLibrary(name: "COpenBLAS", path: "Sources/COpenBLAS"),

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,0 +1,33 @@
+# Releases
+
+## SwiftPM
+
+To use Plumeria Mathematics in another Swift package, add the GitHub package URL and version:
+
+```swift
+.package(url: "https://github.com/bmurakami/plumeria-mathematics.git", from: "0.1.0")
+```
+
+Then add the library product to your target:
+
+```swift
+.product(name: "PlumeriaMathematics", package: "plumeria-mathematics")
+```
+
+## Platform Artifacts
+
+Tagged releases publish archives for every CI-supported platform:
+
+- `plumeria-mathematics-<version>-darwin-m1.tar.gz`: Apple Silicon Macs.
+- `plumeria-mathematics-<version>-linux-x86_64.tar.gz`: typical Intel/AMD Linux computers.
+- `plumeria-mathematics-<version>-linux-aarch64.tar.gz`: Raspberry Pi 3-5 and generic 64-bit ARM Linux machines.
+- `plumeria-mathematics-<version>-linux-neoverse_v2.tar.gz`: AWS Graviton4 and similar Neoverse V2 ARM servers.
+
+Each archive contains:
+
+- `lib/`: the built `libPlumeriaMathematics` dynamic library.
+- `Modules/`: Swift module, documentation, and source-info files emitted by the compiler.
+- `include/`: generated Swift headers and module maps from the release build.
+- `metadata/`: version, platform, Swift compiler version, and host information.
+
+The `.sha256` file next to each archive records the archive checksum.


### PR DESCRIPTION
## Changes

- Added a release workflow for the supported platform artifact matrix.
- Added `BuildScripts/package-release-artifact.sh` to package built libraries, modules, headers, and metadata.
- Made the `PlumeriaMathematics` library product dynamic for artifact packaging.
- Added `RELEASES.md` with source dependency and artifact guidance.
- Ignored local release output directories.

Closes #35