### PR TITLE
Optimize BLAS-backed tensor operations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 .vscode/
 .github/
 dist/
+CLAUDE.md
+AGENTS.md
+

--- a/Sources/AccelerateWrapper/AccelerateOperations.swift
+++ b/Sources/AccelerateWrapper/AccelerateOperations.swift
@@ -4,17 +4,25 @@ import Accelerate
 public struct AccelerateOperations {
     public static func dgemv(
         _ m: Int32, _ n: Int32,
-        _ a: UnsafeMutablePointer<Double>,
-        _ x: UnsafeMutablePointer<Double>,
-        _ y: UnsafeMutablePointer<Double>
+        _ a: [Double],
+        _ x: [Double],
+        _ y: inout [Double]
     ) {
         let alpha: Double = 1.0
         let beta = 0.0
         let lda = Int32(m)
         let incx = Int32(1)
         let incy = Int32(1)
-
-        Accelerate.cblas_dgemv(CblasColMajor, CblasNoTrans, m, n, alpha, a, lda, x, incx, beta, y, incy)
+        a.withUnsafeBufferPointer { a in
+            x.withUnsafeBufferPointer { x in
+                y.withUnsafeMutableBufferPointer { y in
+                    Accelerate.cblas_dgemv(
+                        CblasColMajor, CblasNoTrans, m, n, alpha, a.baseAddress!, lda, x.baseAddress!, incx,
+                        beta, y.baseAddress!, incy
+                    )
+                }
+            }
+        }
     }
 
     public static func zgemv(
@@ -51,16 +59,25 @@ public struct AccelerateOperations {
     
     public static func dgemm(
         _ m: Int32, _ n: Int32, _ k: Int32,
-        _ a: UnsafeMutablePointer<Double>,
-        _ b: UnsafeMutablePointer<Double>,
-        _ c: UnsafeMutablePointer<Double>
+        _ a: [Double],
+        _ b: [Double],
+        _ c: inout [Double]
     ) {
         let alpha: Double = 1.0
         let beta = 0.0
         let lda = m
         let ldb = k
         let ldc = m
-        Accelerate.cblas_dgemm(CblasColMajor, CblasNoTrans, CblasNoTrans, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc)
+        a.withUnsafeBufferPointer { a in
+            b.withUnsafeBufferPointer { b in
+                c.withUnsafeMutableBufferPointer { c in
+                    Accelerate.cblas_dgemm(
+                        CblasColMajor, CblasNoTrans, CblasNoTrans, m, n, k, alpha, a.baseAddress!, lda,
+                        b.baseAddress!, ldb, beta, c.baseAddress!, ldc
+                    )
+                }
+            }
+        }
     }
 
     public static func zgemm(
@@ -95,15 +112,26 @@ public struct AccelerateOperations {
         }
     }
 
-    public static func daxpy(_ n: Int32, _ x: inout [Double], _ y: inout [Double]) {
+    public static func daxpy(_ n: Int32, _ x: [Double], _ y: inout [Double]) {
         let alpha = 1.0
         let inc = Int32(1)
-        Accelerate.cblas_daxpy(n, alpha, x, inc, &y, inc)
+        x.withUnsafeBufferPointer { x in
+            y.withUnsafeMutableBufferPointer { y in
+                Accelerate.cblas_daxpy(n, alpha, x.baseAddress!, inc, y.baseAddress!, inc)
+            }
+        }
     }
 
     public static func dscal(_ n: Int32, _ alpha: Double, _ x: inout [Double]) {
         let inc = Int32(1)
         Accelerate.cblas_dscal(n, alpha, &x, inc)
+    }
+
+    public static func dnrm2(_ n: Int32, _ x: [Double]) -> Double {
+        let inc = Int32(1)
+        return x.withUnsafeBufferPointer { x in
+            Accelerate.cblas_dnrm2(n, x.baseAddress!, inc)
+        }
     }
 
     public static func zaxpy(_ n: Int32, _ x: inout [Double], _ y: inout [Double]) {

--- a/Sources/OpenBLASWrapper/OpenBLASOperations.swift
+++ b/Sources/OpenBLASWrapper/OpenBLASOperations.swift
@@ -4,17 +4,25 @@ public enum OpenBLASOperations {
     // MARK: - BLAS
     public static func dgemv(
         _ m: Int32, _ n: Int32,
-        _ a: UnsafeMutablePointer<Double>,
-        _ x: UnsafeMutablePointer<Double>,
-        _ y: UnsafeMutablePointer<Double>
+        _ a: [Double],
+        _ x: [Double],
+        _ y: inout [Double]
     ) {
         let alpha: Double = 1.0
         let beta = 0.0
         let lda = Int32(m)
         let incx = Int32(1)
         let incy = Int32(1)
-        
-        COpenBLAS.cblas_dgemv(CblasColMajor, CblasNoTrans, m, n, alpha, a, lda, x, incx, beta, y, incy)
+        a.withUnsafeBufferPointer { a in
+            x.withUnsafeBufferPointer { x in
+                y.withUnsafeMutableBufferPointer { y in
+                    COpenBLAS.cblas_dgemv(
+                        CblasColMajor, CblasNoTrans, m, n, alpha, a.baseAddress!, lda, x.baseAddress!, incx,
+                        beta, y.baseAddress!, incy
+                    )
+                }
+            }
+        }
     }
 
     public static func zgemv(
@@ -48,16 +56,25 @@ public enum OpenBLASOperations {
     
     public static func dgemm(
         _ m: Int32, _ n: Int32, _ k: Int32,
-        _ a: UnsafeMutablePointer<Double>,
-        _ b: UnsafeMutablePointer<Double>,
-        _ c: UnsafeMutablePointer<Double>
+        _ a: [Double],
+        _ b: [Double],
+        _ c: inout [Double]
     ) {
         let alpha: Double = 1.0
         let beta = 0.0
         let lda = m
         let ldb = k
         let ldc = m
-        COpenBLAS.cblas_dgemm(CblasColMajor, CblasNoTrans, CblasNoTrans, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc)
+        a.withUnsafeBufferPointer { a in
+            b.withUnsafeBufferPointer { b in
+                c.withUnsafeMutableBufferPointer { c in
+                    COpenBLAS.cblas_dgemm(
+                        CblasColMajor, CblasNoTrans, CblasNoTrans, m, n, k, alpha, a.baseAddress!, lda,
+                        b.baseAddress!, ldb, beta, c.baseAddress!, ldc
+                    )
+                }
+            }
+        }
     }
 
     public static func zgemm(
@@ -89,15 +106,26 @@ public enum OpenBLASOperations {
         }
     }
 
-    public static func daxpy(_ n: Int32, _ x: inout [Double], _ y: inout [Double]) {
+    public static func daxpy(_ n: Int32, _ x: [Double], _ y: inout [Double]) {
         let alpha = 1.0
         let inc = Int32(1)
-        COpenBLAS.cblas_daxpy(n, alpha, x, inc, &y, inc)
+        x.withUnsafeBufferPointer { x in
+            y.withUnsafeMutableBufferPointer { y in
+                COpenBLAS.cblas_daxpy(n, alpha, x.baseAddress!, inc, y.baseAddress!, inc)
+            }
+        }
     }
 
     public static func dscal(_ n: Int32, _ alpha: Double, _ x: inout [Double]) {
         let inc = Int32(1)
         COpenBLAS.cblas_dscal(n, alpha, &x, inc)
+    }
+
+    public static func dnrm2(_ n: Int32, _ x: [Double]) -> Double {
+        let inc = Int32(1)
+        return x.withUnsafeBufferPointer { x in
+            COpenBLAS.cblas_dnrm2(n, x.baseAddress!, inc)
+        }
     }
 
     public static func zaxpy(_ n: Int32, _ x: inout [Double], _ y: inout [Double]) {

--- a/Sources/Tensors/Matrix/MatrixDenseBLAS.swift
+++ b/Sources/Tensors/Matrix/MatrixDenseBLAS.swift
@@ -1,14 +1,18 @@
 import AccelerateWrapper
 import OpenBLASWrapper
 
-public struct MatrixDenseBLAS<S: PluScalar>: PluMatrix, TensorArithmeticBLAS {
+public struct MatrixDenseBLAS<S: PluScalar>: PluMatrix, TensorArithmeticBLAS, MatrixColumnMajorInitializable {
     private var view: TensorFlatView<S>
     public var blasImplementation: BLAS
     
     private func value(row: Int, column: Int) -> S { view[[row, column]] }
     private mutating func setValue(_ value: S, row: Int, column: Int) { view[[row, column]] = value }
 
-    init(rows: Int, columns: Int, values: [S], blasImplementation: BLAS = BLAS.default) {
+    public init(rows: Int, columns: Int, values: [S]) {
+        self.init(rows: rows, columns: columns, values: values, blasImplementation: BLAS.default)
+    }
+
+    init(rows: Int, columns: Int, values: [S], blasImplementation: BLAS) {
         self.view = TensorFlatView(shape: [rows, columns], elements: values)
         self.blasImplementation = blasImplementation
     }

--- a/Sources/Tensors/Matrix/MatrixDenseBLAS.swift
+++ b/Sources/Tensors/Matrix/MatrixDenseBLAS.swift
@@ -43,17 +43,17 @@ public struct MatrixDenseBLAS<S: PluScalar>: PluMatrix, TensorArithmeticBLAS {
             }
         }
         self.view = TensorFlatView(shape: [rows, columns], elements: elements)
-        self.blasImplementation = .openBLAS
+        self.blasImplementation = .default
     }
 
     public init(_ values: TensorNestedArray<S>) {
         precondition(values.shape.count == 2, "Matrix nested array must have rank 2")
         self.view = TensorFlatView(values)
-        self.blasImplementation = .openBLAS
+        self.blasImplementation = .default
     }
 
     public var elements: [S] {
-        get { viewElements(columnMajorOrder: true) }
+        get { columnMajorElements() }
         set {
             precondition(newValue.count == rows * columns, "Matrix element count must match matrix shape")
             view = TensorFlatView(shape: shape, elements: newValue)
@@ -156,17 +156,17 @@ public struct MatrixDenseBLAS<S: PluScalar>: PluMatrix, TensorArithmeticBLAS {
         
         switch S.self {
         case is Double.Type:
-            var A = flatten() as! [Double] // Ax = y
-            var x = v.toArray(round: false) as! [Double]
+            let A = columnMajorElements() as! [Double]
+            let x = vectorElements(v) as! [Double]
             var y = Array(repeating: 0.0, count: rows)
 
             switch blasImplementation {
             #if canImport(Accelerate)
             case .accelerate:
-                AccelerateOperations.dgemv(Int32(rows), Int32(columns), &A, &x, &y)
+                AccelerateOperations.dgemv(Int32(rows), Int32(columns), A, x, &y)
             #endif
             case .openBLAS:
-                OpenBLASOperations.dgemv(Int32(rows), Int32(columns), &A, &x, &y)
+                OpenBLASOperations.dgemv(Int32(rows), Int32(columns), A, x, &y)
             }
 
             return V(y as! [S])
@@ -194,16 +194,16 @@ public struct MatrixDenseBLAS<S: PluScalar>: PluMatrix, TensorArithmeticBLAS {
         precondition(columns == m.rows, "Number of matrix columns must match matrix rows")
         switch S.self {
         case is Double.Type:
-            var A = flatten() as! [Double]
-            var B = m.flatten() as! [Double]
+            let A = columnMajorElements() as! [Double]
+            let B = matrixElements(m) as! [Double]
             var C = Array(repeating: 0.0, count: rows * m.columns)
             switch blasImplementation {
             #if canImport(Accelerate)
             case .accelerate:
-                AccelerateOperations.dgemm(Int32(rows), Int32(m.columns), Int32(columns), &A, &B, &C)
+                AccelerateOperations.dgemm(Int32(rows), Int32(m.columns), Int32(columns), A, B, &C)
             #endif
             case .openBLAS:
-                OpenBLASOperations.dgemm(Int32(rows), Int32(m.columns), Int32(columns), &A, &B, &C)
+                OpenBLASOperations.dgemm(Int32(rows), Int32(m.columns), Int32(columns), A, B, &C)
             }
             return MatrixDenseBLAS(rows: rows, columns: m.columns, values: C as! [S])
         case is Complex.Type:
@@ -244,7 +244,7 @@ public struct MatrixDenseBLAS<S: PluScalar>: PluMatrix, TensorArithmeticBLAS {
     }
     
     public func flatten(columnMajorOrder: Bool = true) -> [S] {
-        viewElements(columnMajorOrder: columnMajorOrder)
+        columnMajorOrder ? columnMajorElements() : viewElements(columnMajorOrder: false)
     }
     
     public static func == (lhs: MatrixDenseBLAS<S>, rhs: MatrixDenseBLAS<S>) -> Bool {
@@ -260,6 +260,20 @@ public struct MatrixDenseBLAS<S: PluScalar>: PluMatrix, TensorArithmeticBLAS {
             }
         }
         return elements
+    }
+
+    private func columnMajorElements() -> [S] {
+        view.contiguousElements ?? viewElements(columnMajorOrder: true)
+    }
+
+    private func vectorElements<V: PluVector>(_ vector: V) -> [S] where V.S == S {
+        if let vector = vector as? VectorDenseBLAS<S> { return vector.elements }
+        return vector.toArray(round: false)
+    }
+
+    private func matrixElements<M: PluMatrix>(_ matrix: M) -> [S] where M.S == S {
+        if let matrix = matrix as? MatrixDenseBLAS<S> { return matrix.columnMajorElements() }
+        return matrix.flatten(columnMajorOrder: true)
     }
 
     private static func interleaved(_ values: [Complex]) -> [Double] {

--- a/Sources/Tensors/Matrix/MatrixDenseReference.swift
+++ b/Sources/Tensors/Matrix/MatrixDenseReference.swift
@@ -1,4 +1,4 @@
-public struct MatrixDenseReference<S: PluScalar>: PluMatrix, TensorArithmeticReference {
+public struct MatrixDenseReference<S: PluScalar>: PluMatrix, TensorArithmeticReference, MatrixColumnMajorInitializable {
     private var values: [[S]]
     
     // MARK: - PluMatrix conformance
@@ -23,6 +23,13 @@ public struct MatrixDenseReference<S: PluScalar>: PluMatrix, TensorArithmeticRef
 
     public init(rows: Int, columns: Int, initialValue: S = .zero) {
         values = Array(repeating: Array(repeating: initialValue, count: columns), count: rows)
+    }
+
+    public init(rows: Int, columns: Int, values: [S]) {
+        precondition(values.count == rows * columns, "Matrix value count must match matrix shape")
+        self.values = (0..<rows).map { row in
+            (0..<columns).map { column in values[row + rows * column] }
+        }
     }
 
     public init(shape: [Int], initialValue: S) {

--- a/Sources/Tensors/Protocols/TensorArithmeticBLAS.swift
+++ b/Sources/Tensors/Protocols/TensorArithmeticBLAS.swift
@@ -49,9 +49,9 @@ extension TensorArithmeticBLAS where Magnitude == S.Magnitude {
     private static func sum(_ left: [S], _ right: [S]) -> [S] {
         switch S.self {
         case is Double.Type:
-            var x = right as! [Double]
+            let x = right as! [Double]
             var y = left as! [Double]
-            axpy(Int32(y.count), &x, &y)
+            axpy(Int32(y.count), x, &y)
             return y as! [S]
         case is Complex.Type:
             var x = interleaved(right as! [Complex])
@@ -79,11 +79,11 @@ extension TensorArithmeticBLAS where Magnitude == S.Magnitude {
         }
     }
 
-    private static func axpy(_ n: Int32, _ x: inout [Double], _ y: inout [Double]) {
+    private static func axpy(_ n: Int32, _ x: [Double], _ y: inout [Double]) {
         #if canImport(Accelerate)
-        AccelerateOperations.daxpy(n, &x, &y)
+        AccelerateOperations.daxpy(n, x, &y)
         #else
-        OpenBLASOperations.daxpy(n, &x, &y)
+        OpenBLASOperations.daxpy(n, x, &y)
         #endif
     }
 

--- a/Sources/Tensors/Protocols/TensorIndex.swift
+++ b/Sources/Tensors/Protocols/TensorIndex.swift
@@ -17,12 +17,14 @@ public func multiply<L: TensorMultiplication, R: TensorMultiplication>(
     precondition(rightIndices.count == right.rank, "Right index count must match tensor rank")
     precondition(Set(leftIndices).count == leftIndices.count, "Left indices must not repeat")
     precondition(Set(rightIndices).count == rightIndices.count, "Right indices must not repeat")
-    let rightAxisByIndex = Dictionary(uniqueKeysWithValues: rightIndices.enumerated().map { ($0.element, $0.offset) })
-    let axes = leftIndices.enumerated().compactMap { leftAxis, index -> (left: Int, right: Int)? in
-        guard let rightAxis = rightAxisByIndex[index] else { return nil }
-        return (leftAxis, rightAxis)
+    let rightPositionByIndex = Dictionary(
+        uniqueKeysWithValues: rightIndices.enumerated().map { ($0.element, $0.offset) }
+    )
+    let contractedIndices = leftIndices.enumerated().compactMap { leftPosition, index -> (left: Int, right: Int)? in
+        guard let rightPosition = rightPositionByIndex[index] else { return nil }
+        return (leftPosition, rightPosition)
     }
-    return left.times(right, contract: axes)
+    return left.times(right, contract: contractedIndices)
 }
 
 public func multiply<L: TensorMultiplication, R: TensorMultiplication>(
@@ -48,13 +50,17 @@ public func permute<T: TensorMultiplication>(
     precondition(destinationIndices.count == tensor.rank, "Destination index count must match tensor rank")
     precondition(Set(sourceIndices).count == sourceIndices.count, "Source indices must not repeat")
     precondition(Set(destinationIndices) == Set(sourceIndices), "Destination indices must permute source indices")
-    let sourceAxisByIndex = Dictionary(uniqueKeysWithValues: sourceIndices.enumerated().map { ($0.element, $0.offset) })
-    let sourceAxes = destinationIndices.map { sourceAxisByIndex[$0]! }
-    let resultShape = sourceAxes.map { tensor.shape[$0] }
+    let sourcePositionByIndex = Dictionary(
+        uniqueKeysWithValues: sourceIndices.enumerated().map { ($0.element, $0.offset) }
+    )
+    let sourcePositions = destinationIndices.map { sourcePositionByIndex[$0]! }
+    let resultShape = sourcePositions.map { tensor.shape[$0] }
     var result = T(shape: resultShape, initialValue: .zero)
     for resultIndex in indexCombinations(for: resultShape) {
         var sourceIndex = Array(repeating: 0, count: tensor.rank)
-        for (resultAxis, sourceAxis) in sourceAxes.enumerated() { sourceIndex[sourceAxis] = resultIndex[resultAxis] }
+        for (resultPosition, sourcePosition) in sourcePositions.enumerated() {
+            sourceIndex[sourcePosition] = resultIndex[resultPosition]
+        }
         result[resultIndex] = tensor[sourceIndex]
     }
     return result

--- a/Sources/Tensors/Protocols/TensorMultiplication.swift
+++ b/Sources/Tensors/Protocols/TensorMultiplication.swift
@@ -1,33 +1,41 @@
-public protocol TensorMultiplication: TensorStructure {
-    associatedtype MatrixImplementation: PluMatrix where MatrixImplementation.S == S
+public protocol MatrixColumnMajorInitializable: PluMatrix {
+    init(rows: Int, columns: Int, values: [S])
+}
 
+public protocol TensorMultiplication: TensorStructure {
+    associatedtype MatrixImplementation: MatrixColumnMajorInitializable where MatrixImplementation.S == S
+
+    var elements: [S] { get }
     init(shape: [Int], initialValue: S)
     subscript(_ indices: [Int]) -> S { get set }
 }
 
 extension TensorMultiplication {
-    public func times<T: TensorMultiplication>(_ other: T, contract axes: [(left: Int, right: Int)]) -> Self
+    public func times<T: TensorMultiplication>(_ other: T, contract indices: [(left: Int, right: Int)]) -> Self
     where T.S == S {
-        validateContraction(axes, with: other)
-        let leftContractedAxes = Set(axes.map(\.left))
-        let rightContractedAxes = Set(axes.map(\.right))
-        let leftFreeAxes = (0..<rank).filter { !leftContractedAxes.contains($0) }
-        let rightFreeAxes = (0..<other.rank).filter { !rightContractedAxes.contains($0) }
-        let leftFreeShape = leftFreeAxes.map { shape[$0] }
-        let rightFreeShape = rightFreeAxes.map { other.shape[$0] }
-        let contractShape = axes.map { shape[$0.left] }
+        validateContraction(indices, with: other)
+        let leftContractedIndices = Set(indices.map(\.left))
+        let rightContractedIndices = Set(indices.map(\.right))
+        let leftFreeIndices = (0..<rank).filter { !leftContractedIndices.contains($0) }
+        let rightFreeIndices = (0..<other.rank).filter { !rightContractedIndices.contains($0) }
+        let leftFreeShape = leftFreeIndices.map { shape[$0] }
+        let rightFreeShape = rightFreeIndices.map { other.shape[$0] }
+        let contractShape = indices.map { shape[$0.left] }
         let resultShape = leftFreeShape + rightFreeShape
         var result = Self(shape: resultShape, initialValue: .zero)
         let leftRows = Self.countElements(for: leftFreeShape)
         let shared = Self.countElements(for: contractShape)
         let rightColumns = Self.countElements(for: rightFreeShape)
         if Self.countElements(for: resultShape) == 0 || shared == 0 { return result }
-        let leftMatrix = matricizedLeftTensor(freeAxes: leftFreeAxes, contractAxes: axes.map(\.left))
-        let rightMatrix = other.matricizedRightTensor(freeAxes: rightFreeAxes, contractAxes: axes.map(\.right))
+        let leftMatrix = matricizedLeftTensor(freeIndices: leftFreeIndices, contractIndices: indices.map(\.left))
+        let rightMatrix = other.matricizedRightTensor(
+            freeIndices: rightFreeIndices,
+            contractIndices: indices.map(\.right)
+        )
         let product = leftMatrix * rightMatrix
         for resultIndex in Self.indexCombinations(for: resultShape) {
-            let leftFreeIndex = Array(resultIndex.prefix(leftFreeAxes.count))
-            let rightFreeIndex = Array(resultIndex.dropFirst(leftFreeAxes.count))
+            let leftFreeIndex = Array(resultIndex.prefix(leftFreeIndices.count))
+            let rightFreeIndex = Array(resultIndex.dropFirst(leftFreeIndices.count))
             let row = Self.linearIndex(leftFreeIndex, shape: leftFreeShape)
             let column = Self.linearIndex(rightFreeIndex, shape: rightFreeShape)
             precondition(row < leftRows && column < rightColumns, "Tensor contraction output index is out of bounds")
@@ -36,9 +44,16 @@ extension TensorMultiplication {
         return result
     }
 
-    private func matricizedLeftTensor(freeAxes: [Int], contractAxes: [Int]) -> MatrixImplementation {
-        let freeShape = freeAxes.map { shape[$0] }
-        let contractShape = contractAxes.map { shape[$0] }
+    private func matricizedLeftTensor(freeIndices: [Int], contractIndices: [Int]) -> MatrixImplementation {
+        let freeShape = freeIndices.map { shape[$0] }
+        let contractShape = contractIndices.map { shape[$0] }
+        if freeIndices + contractIndices == Array(0..<rank) {
+            return MatrixImplementation(
+                rows: Self.countElements(for: freeShape),
+                columns: Self.countElements(for: contractShape),
+                values: elements
+            )
+        }
         var matrix = MatrixImplementation(
             rows: Self.countElements(for: freeShape),
             columns: Self.countElements(for: contractShape),
@@ -47,8 +62,8 @@ extension TensorMultiplication {
         for freeIndex in Self.indexCombinations(for: freeShape) {
             for contractIndex in Self.indexCombinations(for: contractShape) {
                 var tensorIndex = Array(repeating: 0, count: rank)
-                for (position, axis) in freeAxes.enumerated() { tensorIndex[axis] = freeIndex[position] }
-                for (position, axis) in contractAxes.enumerated() { tensorIndex[axis] = contractIndex[position] }
+                for (position, index) in freeIndices.enumerated() { tensorIndex[index] = freeIndex[position] }
+                for (position, index) in contractIndices.enumerated() { tensorIndex[index] = contractIndex[position] }
                 matrix[
                     Self.linearIndex(freeIndex, shape: freeShape),
                     Self.linearIndex(contractIndex, shape: contractShape)
@@ -58,9 +73,16 @@ extension TensorMultiplication {
         return matrix
     }
 
-    private func matricizedRightTensor(freeAxes: [Int], contractAxes: [Int]) -> MatrixImplementation {
-        let freeShape = freeAxes.map { shape[$0] }
-        let contractShape = contractAxes.map { shape[$0] }
+    private func matricizedRightTensor(freeIndices: [Int], contractIndices: [Int]) -> MatrixImplementation {
+        let freeShape = freeIndices.map { shape[$0] }
+        let contractShape = contractIndices.map { shape[$0] }
+        if contractIndices + freeIndices == Array(0..<rank) {
+            return MatrixImplementation(
+                rows: Self.countElements(for: contractShape),
+                columns: Self.countElements(for: freeShape),
+                values: elements
+            )
+        }
         var matrix = MatrixImplementation(
             rows: Self.countElements(for: contractShape),
             columns: Self.countElements(for: freeShape),
@@ -69,8 +91,8 @@ extension TensorMultiplication {
         for contractIndex in Self.indexCombinations(for: contractShape) {
             for freeIndex in Self.indexCombinations(for: freeShape) {
                 var tensorIndex = Array(repeating: 0, count: rank)
-                for (position, axis) in contractAxes.enumerated() { tensorIndex[axis] = contractIndex[position] }
-                for (position, axis) in freeAxes.enumerated() { tensorIndex[axis] = freeIndex[position] }
+                for (position, index) in contractIndices.enumerated() { tensorIndex[index] = contractIndex[position] }
+                for (position, index) in freeIndices.enumerated() { tensorIndex[index] = freeIndex[position] }
                 matrix[
                     Self.linearIndex(contractIndex, shape: contractShape),
                     Self.linearIndex(freeIndex, shape: freeShape)
@@ -80,16 +102,19 @@ extension TensorMultiplication {
         return matrix
     }
 
-    private func validateContraction<T: TensorMultiplication>(_ axes: [(left: Int, right: Int)], with other: T)
+    private func validateContraction<T: TensorMultiplication>(_ indices: [(left: Int, right: Int)], with other: T)
     where T.S == S {
-        var leftAxes = Set<Int>()
-        var rightAxes = Set<Int>()
-        for axisPair in axes {
-            precondition(axisPair.left >= 0 && axisPair.left < rank, "Left contraction axis is out of bounds")
-            precondition(axisPair.right >= 0 && axisPair.right < other.rank, "Right contraction axis is out of bounds")
-            precondition(leftAxes.insert(axisPair.left).inserted, "Left contraction axes must be unique")
-            precondition(rightAxes.insert(axisPair.right).inserted, "Right contraction axes must be unique")
-            precondition(shape[axisPair.left] == other.shape[axisPair.right], "Contracted dimensions must match")
+        var leftIndices = Set<Int>()
+        var rightIndices = Set<Int>()
+        for indexPair in indices {
+            precondition(indexPair.left >= 0 && indexPair.left < rank, "Left contraction index is out of bounds")
+            precondition(
+                indexPair.right >= 0 && indexPair.right < other.rank,
+                "Right contraction index is out of bounds"
+            )
+            precondition(leftIndices.insert(indexPair.left).inserted, "Left contraction indices must be unique")
+            precondition(rightIndices.insert(indexPair.right).inserted, "Right contraction indices must be unique")
+            precondition(shape[indexPair.left] == other.shape[indexPair.right], "Contracted dimensions must match")
         }
     }
 

--- a/Sources/Tensors/Storage/TensorFlatView.swift
+++ b/Sources/Tensors/Storage/TensorFlatView.swift
@@ -7,6 +7,7 @@ public struct TensorFlatView<Scalar: PluScalar>: TensorView, Equatable {
     public var count: Int { shape.reduce(1, *) }
     public var elements: [Scalar] { (0..<count).map { self[tensorIndices(forFlatIndex: $0)] } }
     public var isContiguous: Bool { strides == Self.columnMajorStrides(for: shape) }
+    public var contiguousElements: [Scalar]? { isContiguous && offset == 0 ? storage.elements : nil }
     
     public init(shape: [Int]) {
         precondition(shape.allSatisfy { $0 >= 0 }, "Tensor shape dimensions must be non-negative")

--- a/Sources/Tensors/Tensor/TensorDenseBLAS.swift
+++ b/Sources/Tensors/Tensor/TensorDenseBLAS.swift
@@ -6,7 +6,7 @@ public struct TensorDenseBLAS<S: PluScalar>: TensorMultiplication, TensorArithme
     public var shape: [Int] { view.shape }
     public var rank: Int { view.rank }
     public var elements: [S] {
-        get { view.elements }
+        get { view.contiguousElements ?? view.elements }
         set { view = TensorFlatView(shape: shape, elements: newValue) }
     }
 

--- a/Sources/Tensors/Tensor/TensorDenseReference.swift
+++ b/Sources/Tensors/Tensor/TensorDenseReference.swift
@@ -6,6 +6,7 @@ public struct TensorDenseReference<S: PluScalar>: PluTensor, TensorStructure, Te
 
     public let shape: [Int]
     public var rank: Int { shape.count }
+    public var elements: [S] { storage.columnMajorElements() }
 
     public init(_ values: TensorNestedArray<S>) {
         self.shape = values.shape

--- a/Sources/Tensors/Vector/VectorDenseBLAS.swift
+++ b/Sources/Tensors/Vector/VectorDenseBLAS.swift
@@ -1,3 +1,8 @@
+#if canImport(Accelerate)
+import AccelerateWrapper
+#endif
+import OpenBLASWrapper
+
 public struct VectorDenseBLAS<S: PluScalar>: PluVector, TensorArithmeticBLAS {
     public var elements: [S]
 
@@ -57,5 +62,15 @@ public struct VectorDenseBLAS<S: PluScalar>: PluVector, TensorArithmeticBLAS {
                      "Vector shape \(shape) requires \(shape[0]) elements, but got \(elements.count)")
 
         self.init(elements)
+    }
+}
+
+extension VectorDenseBLAS where S == Double {
+    public func magnitude() -> Double {
+        #if canImport(Accelerate)
+        return AccelerateOperations.dnrm2(Int32(size), elements)
+        #else
+        return OpenBLASOperations.dnrm2(Int32(size), elements)
+        #endif
     }
 }


### PR DESCRIPTION
## Changes

- Uses immutable BLAS input buffers to avoid unnecessary operand copies.
- Uses contiguous tensor storage directly for BLAS matrix and tensor operations.
- Uses `BLAS.default` for dense matrix nested-array initializers.
- Adds BLAS-backed real vector magnitude.
- Skips tensor contraction packing when free and contracted indices already match column-major storage order.
- Uses index/index terminology instead of axis/axes in tensor multiplication code.

Closes #39