### PR TITLE
Add real Float scalar support

### DIFF
--- a/Sources/AccelerateWrapper/AccelerateOperations.swift
+++ b/Sources/AccelerateWrapper/AccelerateOperations.swift
@@ -2,6 +2,24 @@
 import Accelerate
 
 public struct AccelerateOperations {
+    public static func sgemv(_ m: Int32, _ n: Int32, _ a: [Float], _ x: [Float], _ y: inout [Float]) {
+        let alpha: Float = 1.0
+        let beta: Float = 0.0
+        let lda = Int32(m)
+        let incx = Int32(1)
+        let incy = Int32(1)
+        a.withUnsafeBufferPointer { a in
+            x.withUnsafeBufferPointer { x in
+                y.withUnsafeMutableBufferPointer { y in
+                    Accelerate.cblas_sgemv(
+                        CblasColMajor, CblasNoTrans, m, n, alpha, a.baseAddress!, lda, x.baseAddress!, incx,
+                        beta, y.baseAddress!, incy
+                    )
+                }
+            }
+        }
+    }
+
     public static func dgemv(_ m: Int32, _ n: Int32, _ a: [Double], _ x: [Double], _ y: inout [Double]) {
         let alpha: Double = 1.0
         let beta = 0.0
@@ -66,6 +84,26 @@ public struct AccelerateOperations {
         }
     }
 
+    public static func sgemm(
+        _ m: Int32, _ n: Int32, _ k: Int32, _ a: [Float], _ b: [Float], _ c: inout [Float]
+    ) {
+        let alpha: Float = 1.0
+        let beta: Float = 0.0
+        let lda = m
+        let ldb = k
+        let ldc = m
+        a.withUnsafeBufferPointer { a in
+            b.withUnsafeBufferPointer { b in
+                c.withUnsafeMutableBufferPointer { c in
+                    Accelerate.cblas_sgemm(
+                        CblasColMajor, CblasNoTrans, CblasNoTrans, m, n, k, alpha, a.baseAddress!, lda,
+                        b.baseAddress!, ldb, beta, c.baseAddress!, ldc
+                    )
+                }
+            }
+        }
+    }
+
     public static func zgemm(
         _ m: Int32, _ n: Int32, _ k: Int32, _ a: inout [Double], _ b: inout [Double], _ c: inout [Double]
     ) {
@@ -104,15 +142,37 @@ public struct AccelerateOperations {
         }
     }
 
+    public static func saxpy(_ n: Int32, _ x: [Float], _ y: inout [Float]) {
+        let alpha: Float = 1.0
+        let inc = Int32(1)
+        x.withUnsafeBufferPointer { x in
+            y.withUnsafeMutableBufferPointer { y in
+                Accelerate.cblas_saxpy(n, alpha, x.baseAddress!, inc, y.baseAddress!, inc)
+            }
+        }
+    }
+
     public static func dscal(_ n: Int32, _ alpha: Double, _ x: inout [Double]) {
         let inc = Int32(1)
         Accelerate.cblas_dscal(n, alpha, &x, inc)
+    }
+
+    public static func sscal(_ n: Int32, _ alpha: Float, _ x: inout [Float]) {
+        let inc = Int32(1)
+        Accelerate.cblas_sscal(n, alpha, &x, inc)
     }
 
     public static func dnrm2(_ n: Int32, _ x: [Double]) -> Double {
         let inc = Int32(1)
         return x.withUnsafeBufferPointer { x in
             Accelerate.cblas_dnrm2(n, x.baseAddress!, inc)
+        }
+    }
+
+    public static func snrm2(_ n: Int32, _ x: [Float]) -> Float {
+        let inc = Int32(1)
+        return x.withUnsafeBufferPointer { x in
+            Accelerate.cblas_snrm2(n, x.baseAddress!, inc)
         }
     }
 

--- a/Sources/OpenBLASWrapper/OpenBLASOperations.swift
+++ b/Sources/OpenBLASWrapper/OpenBLASOperations.swift
@@ -1,6 +1,24 @@
 import COpenBLAS
 
 public enum OpenBLASOperations {
+    public static func sgemv(_ m: Int32, _ n: Int32, _ a: [Float], _ x: [Float], _ y: inout [Float]) {
+        let alpha: Float = 1.0
+        let beta: Float = 0.0
+        let lda = Int32(m)
+        let incx = Int32(1)
+        let incy = Int32(1)
+        a.withUnsafeBufferPointer { a in
+            x.withUnsafeBufferPointer { x in
+                y.withUnsafeMutableBufferPointer { y in
+                    COpenBLAS.cblas_sgemv(
+                        CblasColMajor, CblasNoTrans, m, n, alpha, a.baseAddress!, lda, x.baseAddress!, incx,
+                        beta, y.baseAddress!, incy
+                    )
+                }
+            }
+        }
+    }
+
     public static func dgemv(_ m: Int32, _ n: Int32, _ a: [Double], _ x: [Double], _ y: inout [Double]) {
         let alpha: Double = 1.0
         let beta = 0.0
@@ -62,6 +80,26 @@ public enum OpenBLASOperations {
         }
     }
 
+    public static func sgemm(
+        _ m: Int32, _ n: Int32, _ k: Int32, _ a: [Float], _ b: [Float], _ c: inout [Float]
+    ) {
+        let alpha: Float = 1.0
+        let beta: Float = 0.0
+        let lda = m
+        let ldb = k
+        let ldc = m
+        a.withUnsafeBufferPointer { a in
+            b.withUnsafeBufferPointer { b in
+                c.withUnsafeMutableBufferPointer { c in
+                    COpenBLAS.cblas_sgemm(
+                        CblasColMajor, CblasNoTrans, CblasNoTrans, m, n, k, alpha, a.baseAddress!, lda,
+                        b.baseAddress!, ldb, beta, c.baseAddress!, ldc
+                    )
+                }
+            }
+        }
+    }
+
     public static func zgemm(
         _ m: Int32, _ n: Int32, _ k: Int32, _ a: inout [Double], _ b: inout [Double], _ c: inout [Double]
     ) {
@@ -97,15 +135,37 @@ public enum OpenBLASOperations {
         }
     }
 
+    public static func saxpy(_ n: Int32, _ x: [Float], _ y: inout [Float]) {
+        let alpha: Float = 1.0
+        let inc = Int32(1)
+        x.withUnsafeBufferPointer { x in
+            y.withUnsafeMutableBufferPointer { y in
+                COpenBLAS.cblas_saxpy(n, alpha, x.baseAddress!, inc, y.baseAddress!, inc)
+            }
+        }
+    }
+
     public static func dscal(_ n: Int32, _ alpha: Double, _ x: inout [Double]) {
         let inc = Int32(1)
         COpenBLAS.cblas_dscal(n, alpha, &x, inc)
+    }
+
+    public static func sscal(_ n: Int32, _ alpha: Float, _ x: inout [Float]) {
+        let inc = Int32(1)
+        COpenBLAS.cblas_sscal(n, alpha, &x, inc)
     }
 
     public static func dnrm2(_ n: Int32, _ x: [Double]) -> Double {
         let inc = Int32(1)
         return x.withUnsafeBufferPointer { x in
             COpenBLAS.cblas_dnrm2(n, x.baseAddress!, inc)
+        }
+    }
+
+    public static func snrm2(_ n: Int32, _ x: [Float]) -> Float {
+        let inc = Int32(1)
+        return x.withUnsafeBufferPointer { x in
+            COpenBLAS.cblas_snrm2(n, x.baseAddress!, inc)
         }
     }
 

--- a/Sources/PlumeriaBenchmarks/main.swift
+++ b/Sources/PlumeriaBenchmarks/main.swift
@@ -30,6 +30,16 @@ func compareBenchmark(
     return referenceChecksum + blasChecksum
 }
 
+func compareFloatBenchmark(
+    _ operation: String, _ size: String, samples: Int = 5, iterations: Int = 1,
+    double: () -> Double, float: () -> Double
+) -> Double {
+    let (doubleResult, doubleChecksum) = measure(samples: samples, iterations: iterations, operation: double)
+    let (floatResult, floatChecksum) = measure(samples: samples, iterations: iterations, operation: float)
+    printFloatBenchmark(operation, size, double: doubleResult, float: floatResult)
+    return doubleChecksum + floatChecksum
+}
+
 func summarize(_ values: [Double]) -> TimedResult {
     let sorted = values.sorted()
     return TimedResult(best: sorted[0], median: sorted[sorted.count / 2])
@@ -47,6 +57,14 @@ func printBenchmark(_ operation: String, _ size: String, reference: TimedResult,
     print("")
 }
 
+func printFloatBenchmark(_ operation: String, _ size: String, double: TimedResult, float: TimedResult) {
+    print("  \(operation) \(size)")
+    print("    Double: median \(format(double.median)) ms, best \(format(double.best)) ms")
+    print("    Float:  median \(format(float.median)) ms, best \(format(float.best)) ms")
+    print("    ratio:  \(ratio(double: double.median, float: float.median))")
+    print("")
+}
+
 func ratio(reference: Double, blas: Double) -> String {
     if reference == 0 && blas == 0 { return "same speed" }
     if reference == 0 { return "reference faster" }
@@ -55,6 +73,16 @@ func ratio(reference: Double, blas: Double) -> String {
         return "reference \(format(blas / reference))x faster"
     }
     return "BLAS \(format(reference / blas))x faster"
+}
+
+func ratio(double: Double, float: Double) -> String {
+    if double == 0 && float == 0 { return "same speed" }
+    if double == 0 { return "Double faster" }
+    if float == 0 { return "Float faster" }
+    if double < float {
+        return "Double \(format(float / double))x faster"
+    }
+    return "Float \(format(double / float))x faster"
 }
 
 func commandOutput(_ command: String, _ arguments: [String]) -> String {
@@ -78,6 +106,10 @@ func vectorValues(count: Int) -> [Double] {
     (0..<count).map { Double(($0 % 97) - 48) / 7.0 }
 }
 
+func vectorFloatValues(count: Int) -> [Float] {
+    vectorValues(count: count).map(Float.init)
+}
+
 func matrixRows(rows: Int, columns: Int) -> [[Double]] {
     var values: [[Double]] = []
     values.reserveCapacity(rows)
@@ -92,10 +124,21 @@ func matrixRows(rows: Int, columns: Int) -> [[Double]] {
     return values
 }
 
+func matrixFloatRows(rows: Int, columns: Int) -> [[Float]] {
+    matrixRows(rows: rows, columns: columns).map { $0.map(Float.init) }
+}
+
 func fillTensor<T: TensorMultiplication>(_ tensor: inout T) where T.S == Double {
     for index in indexCombinations(for: tensor.shape) {
         let weighted = index.enumerated().reduce(0) { $0 + ($1.offset + 1) * ($1.element + 1) }
         tensor[index] = Double((weighted % 29) - 14) / 5.0
+    }
+}
+
+func fillFloatTensor<T: TensorMultiplication>(_ tensor: inout T) where T.S == Float {
+    for index in indexCombinations(for: tensor.shape) {
+        let weighted = index.enumerated().reduce(0) { $0 + ($1.offset + 1) * ($1.element + 1) }
+        tensor[index] = Float((weighted % 29) - 14) / 5.0
     }
 }
 
@@ -251,6 +294,69 @@ func benchmarkTensors() -> Double {
     return checksum
 }
 
+func benchmarkFloatScalars() -> Double {
+    print("Float vs Double")
+    let doubleVector = VectorDenseBLAS(vectorValues(count: 100_000))
+    let floatVector = VectorDenseBLAS(vectorFloatValues(count: 100_000))
+    let doubleMatrixVector = VectorDenseBLAS(vectorValues(count: 384))
+    let floatMatrixVector = VectorDenseBLAS(vectorFloatValues(count: 384))
+    let doubleMatrixRows = matrixRows(rows: 384, columns: 384)
+    let floatMatrixRows = matrixFloatRows(rows: 384, columns: 384)
+    let doubleMatrix = MatrixDenseBLAS(doubleMatrixRows)
+    let floatMatrix = MatrixDenseBLAS(floatMatrixRows)
+    let doubleLeftRows = matrixRows(rows: 128, columns: 128)
+    let floatLeftRows = matrixFloatRows(rows: 128, columns: 128)
+    let doubleRightRows = matrixRows(rows: 128, columns: 128)
+    let floatRightRows = matrixFloatRows(rows: 128, columns: 128)
+    let doubleLeftMatrix = MatrixDenseBLAS(doubleLeftRows)
+    let floatLeftMatrix = MatrixDenseBLAS(floatLeftRows)
+    let doubleRightMatrix = MatrixDenseBLAS(doubleRightRows)
+    let floatRightMatrix = MatrixDenseBLAS(floatRightRows)
+    var doubleTensor = TensorDenseBLAS<Double>(shape: [16, 24, 16], initialValue: 0.0)
+    var doubleRightTensor = TensorDenseBLAS<Double>(shape: [16, 16], initialValue: 0.0)
+    var floatTensor = TensorDenseBLAS<Float>(shape: [16, 24, 16], initialValue: 0.0)
+    var floatRightTensor = TensorDenseBLAS<Float>(shape: [16, 16], initialValue: 0.0)
+    fillTensor(&doubleTensor)
+    fillTensor(&doubleRightTensor)
+    fillFloatTensor(&floatTensor)
+    fillFloatTensor(&floatRightTensor)
+    var checksum = 0.0
+    checksum += compareFloatBenchmark("vector add", "100,000", iterations: 10, double: {
+        let result = doubleVector + doubleVector
+        return result[0] + result[result.size - 1]
+    }, float: {
+        let result = floatVector + floatVector
+        return Double(result[0] + result[result.size - 1])
+    })
+    checksum += compareFloatBenchmark("magnitude", "100,000", iterations: 10, double: {
+        doubleVector.magnitude()
+    }, float: {
+        Double(floatVector.magnitude())
+    })
+    checksum += compareFloatBenchmark("matrix-vector multiply", "384x384", double: {
+        let result = doubleMatrix * doubleMatrixVector
+        return result[0] + result[result.size - 1]
+    }, float: {
+        let result = floatMatrix * floatMatrixVector
+        return Double(result[0] + result[result.size - 1])
+    })
+    checksum += compareFloatBenchmark("matrix-matrix multiply", "128x128", double: {
+        let result = doubleLeftMatrix * doubleRightMatrix
+        return result[0, 0] + result[result.rows - 1, result.columns - 1]
+    }, float: {
+        let result = floatLeftMatrix * floatRightMatrix
+        return Double(result[0, 0] + result[result.rows - 1, result.columns - 1])
+    })
+    checksum += compareFloatBenchmark("tensor contraction", "16x24x16,16x16", double: {
+        let result = multiply(doubleTensor, ["i", "j", "k"], doubleRightTensor, ["k", "l"])
+        return result[[0, 0, 0]] + result[[15, 23, 15]]
+    }, float: {
+        let result = multiply(floatTensor, ["i", "j", "k"], floatRightTensor, ["k", "l"])
+        return Double(result[[0, 0, 0]] + result[[15, 23, 15]])
+    })
+    return checksum
+}
+
 let swiftVersion = commandOutput("/usr/bin/env", ["swift", "--version"])
 let platform = commandOutput("/usr/bin/env", ["uname", "-m"])
 
@@ -258,5 +364,5 @@ print("PlumeriaBenchmarks")
 print("Swift: \(swiftVersion)")
 print("Platform: \(platform)")
 print("")
-let blackHole = benchmarkVectors() + benchmarkMatrices() + benchmarkTensors()
+let blackHole = benchmarkVectors() + benchmarkMatrices() + benchmarkTensors() + benchmarkFloatScalars()
 print("Checksum: \(blackHole)")

--- a/Sources/Tensors/BLAS.swift
+++ b/Sources/Tensors/BLAS.swift
@@ -25,11 +25,27 @@ public enum BLAS {
         #endif
     }
 
+    static func axpy(_ n: Int32, _ x: [Float], _ y: inout [Float]) {
+        #if canImport(Accelerate)
+        AccelerateOperations.saxpy(n, x, &y)
+        #else
+        OpenBLASOperations.saxpy(n, x, &y)
+        #endif
+    }
+
     static func scal(_ n: Int32, _ alpha: Double, _ x: inout [Double]) {
         #if canImport(Accelerate)
         AccelerateOperations.dscal(n, alpha, &x)
         #else
         OpenBLASOperations.dscal(n, alpha, &x)
+        #endif
+    }
+
+    static func scal(_ n: Int32, _ alpha: Float, _ x: inout [Float]) {
+        #if canImport(Accelerate)
+        AccelerateOperations.sscal(n, alpha, &x)
+        #else
+        OpenBLASOperations.sscal(n, alpha, &x)
         #endif
     }
 

--- a/Sources/Tensors/Core/PluScalar.swift
+++ b/Sources/Tensors/Core/PluScalar.swift
@@ -23,6 +23,15 @@ extension Double: PluScalar {
     }
 }
 
+extension Float: PluScalar {
+    public typealias S = Float
+
+    public func round(precision: Int = 6) -> Float {
+        let multiplier = Float(Foundation.pow(10.0, Double(precision)))
+        return (self * multiplier).rounded() / multiplier
+    }
+}
+
 extension Complex: TensorArithmetic, PluTensor, PluScalar {
     public typealias S = Complex
 

--- a/Sources/Tensors/Matrix/MatrixDenseBLAS.swift
+++ b/Sources/Tensors/Matrix/MatrixDenseBLAS.swift
@@ -178,6 +178,19 @@ extension MatrixDenseBLAS {
                 OpenBLASOperations.dgemv(Int32(rows), Int32(columns), A, x, &y)
             }
             return V(y as! [S])
+        case is Float.Type:
+            let A = columnMajorStorage() as! [Float]
+            let x = vectorElements(v) as! [Float]
+            var y = Array(repeating: Float.zero, count: rows)
+            switch blasImplementation {
+            #if canImport(Accelerate)
+            case .accelerate:
+                AccelerateOperations.sgemv(Int32(rows), Int32(columns), A, x, &y)
+            #endif
+            case .openBLAS:
+                OpenBLASOperations.sgemv(Int32(rows), Int32(columns), A, x, &y)
+            }
+            return V(y as! [S])
         case is Complex.Type:
             var A = MatrixDenseBLAS.interleaved(flatten() as! [Complex])
             var x = MatrixDenseBLAS.interleaved(v.toArray(round: false) as! [Complex])
@@ -210,6 +223,19 @@ extension MatrixDenseBLAS {
             #endif
             case .openBLAS:
                 OpenBLASOperations.dgemm(Int32(rows), Int32(m.columns), Int32(columns), A, B, &C)
+            }
+            return MatrixDenseBLAS(rows: rows, columns: m.columns, values: C as! [S])
+        case is Float.Type:
+            let A = columnMajorStorage() as! [Float]
+            let B = columnMajorElements(from: m) as! [Float]
+            var C = Array(repeating: Float.zero, count: rows * m.columns)
+            switch blasImplementation {
+            #if canImport(Accelerate)
+            case .accelerate:
+                AccelerateOperations.sgemm(Int32(rows), Int32(m.columns), Int32(columns), A, B, &C)
+            #endif
+            case .openBLAS:
+                OpenBLASOperations.sgemm(Int32(rows), Int32(m.columns), Int32(columns), A, B, &C)
             }
             return MatrixDenseBLAS(rows: rows, columns: m.columns, values: C as! [S])
         case is Complex.Type:

--- a/Sources/Tensors/Protocols/TensorArithmeticBLAS.swift
+++ b/Sources/Tensors/Protocols/TensorArithmeticBLAS.swift
@@ -48,6 +48,11 @@ extension TensorArithmeticBLAS {
             var y = left as! [Double]
             BLAS.axpy(Int32(y.count), x, &y)
             return y as! [S]
+        case is Float.Type:
+            let x = right as! [Float]
+            var y = left as! [Float]
+            BLAS.axpy(Int32(y.count), x, &y)
+            return y as! [S]
         case is Complex.Type:
             var x = interleaved(right as! [Complex])
             var y = interleaved(left as! [Complex])
@@ -63,6 +68,10 @@ extension TensorArithmeticBLAS {
         case is Double.Type:
             var result = values as! [Double]
             BLAS.scal(Int32(result.count), scalar as! Double, &result)
+            return result as! [S]
+        case is Float.Type:
+            var result = values as! [Float]
+            BLAS.scal(Int32(result.count), scalar as! Float, &result)
             return result as! [S]
         case is Complex.Type:
             var result = interleaved(values as! [Complex])

--- a/Sources/Tensors/Vector/VectorDenseBLAS.swift
+++ b/Sources/Tensors/Vector/VectorDenseBLAS.swift
@@ -70,12 +70,23 @@ extension VectorDenseBLAS: PluVector {
     }
 
     public func magnitude() -> S.Magnitude {
-        if S.self != Double.self { return elements.map { $0.magnitude * $0.magnitude }.reduce(.zero, +).squareRoot() }
-        let values = elements as! [Double]
-        #if canImport(Accelerate)
-        return AccelerateOperations.dnrm2(Int32(size), values) as! S.Magnitude
-        #else
-        return OpenBLASOperations.dnrm2(Int32(size), values) as! S.Magnitude
-        #endif
+        switch S.self {
+        case is Double.Type:
+            let values = elements as! [Double]
+            #if canImport(Accelerate)
+            return AccelerateOperations.dnrm2(Int32(size), values) as! S.Magnitude
+            #else
+            return OpenBLASOperations.dnrm2(Int32(size), values) as! S.Magnitude
+            #endif
+        case is Float.Type:
+            let values = elements as! [Float]
+            #if canImport(Accelerate)
+            return AccelerateOperations.snrm2(Int32(size), values) as! S.Magnitude
+            #else
+            return OpenBLASOperations.snrm2(Int32(size), values) as! S.Magnitude
+            #endif
+        default:
+            return elements.map { $0.magnitude * $0.magnitude }.reduce(.zero, +).squareRoot()
+        }
     }
 }

--- a/Tests/TensorsTests/FloatTests.swift
+++ b/Tests/TensorsTests/FloatTests.swift
@@ -1,0 +1,61 @@
+import Testing
+@testable import Tensors
+
+@Test func Float_plumeriaScalarSupport() {
+    let value: Float = 1.23456
+
+    #expect(value.round(precision: 2) == 1.23)
+    #expect((value / 2.0).isApproximatelyEqual(to: 0.61728, relativeTolerance: 1e-6))
+}
+
+@Test func Float_vectorReferenceAndBLASOperations() {
+    checkFloatVector(VectorDenseReference<Float>.self)
+    checkFloatVector(VectorDenseBLAS<Float>.self)
+}
+
+@Test func Float_matrixReferenceAndBLASOperations() {
+    checkFloatMatrix(MatrixDenseReference<Float>.self)
+    checkFloatMatrix(MatrixDenseBLAS<Float>.self)
+}
+
+@Test func Float_tensorReferenceAndBLASOperations() {
+    checkFloatTensor(TensorDenseReference<Float>.self)
+    checkFloatTensor(TensorDenseBLAS<Float>.self)
+}
+
+private func checkFloatVector<V: PluVector>(_ type: V.Type) where V.S == Float {
+    let u = V([3.0, 4.0, 12.0])
+    let v = V([2.0, -1.0, 3.0])
+
+    #expect(u.magnitude().isApproximatelyEqual(to: 13.0, relativeTolerance: 1e-6))
+    #expect(u.dot(v) == 38.0)
+    #expect((u + v).toArray() == [5.0, 3.0, 15.0])
+    #expect((u * 2.0).toArray() == [6.0, 8.0, 24.0])
+    #expect((u / 2.0).toArray() == [1.5, 2.0, 6.0])
+}
+
+private func checkFloatMatrix<M: PluMatrix>(_ type: M.Type) where M.S == Float {
+    let left = M([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+    let right = M([[7.0, 8.0], [9.0, 10.0], [11.0, 12.0]])
+    let vector = VectorDenseReference<Float>([2.0, 3.0, 4.0])
+
+    #expect((left * vector).toArray() == [20.0, 47.0])
+    #expect((left * right).toArray() == [[58.0, 64.0], [139.0, 154.0]])
+    #expect((left + left).toArray() == [[2.0, 4.0, 6.0], [8.0, 10.0, 12.0]])
+}
+
+private func checkFloatTensor<T: TensorMultiplication & TensorArithmetic>(_ type: T.Type) where T.S == Float {
+    let leftValues: TensorNestedArray<Float> = [[1.0, 2.0, 0.0], [-1.0, 3.0, 1.0]]
+    let rightValues: TensorNestedArray<Float> = [[2.0, 1.0], [0.0, -1.0], [3.0, 2.0]]
+    let left = T(leftValues)
+    let right = T(rightValues)
+    let product = multiply(left, [TensorIndex("i"), TensorIndex("j")], right, [TensorIndex("j"), TensorIndex("k")])
+
+    #expect((left + left)[[0, 1]] == 4.0)
+    #expect((left * 2.0)[[1, 0]] == -2.0)
+    #expect(product.shape == [2, 2])
+    #expect(product[[0, 0]] == 2.0)
+    #expect(product[[1, 0]] == 1.0)
+    #expect(product[[0, 1]] == -1.0)
+    #expect(product[[1, 1]] == -2.0)
+}

--- a/Tests/TensorsTests/ScalarTests.swift
+++ b/Tests/TensorsTests/ScalarTests.swift
@@ -53,5 +53,7 @@ import Testing
 @Test func PluScalar_roundsWithPrecision() {
     #expect(1.23456.round() == 1.23456)
     #expect(1.23456.round(precision: 2) == 1.23)
+    #expect(Float(1.2345678).round() == 1.234568)
+    #expect(Float(1.2345678).round(precision: 2) == 1.23)
     #expect(Complex(1.23456, -2.34567).round(precision: 2) == Complex(1.23, -2.35))
 }


### PR DESCRIPTION
Closes #45

## Changes
- Added Float conformance to PluScalar with a Float-appropriate default rounding precision.
- Added real Float BLAS wrappers for saxpy, sscal, snrm2, sgemv, and sgemm.
- Routed BLAS-backed tensor arithmetic through Float axpy/scal paths.
- Added Float support for VectorDenseBLAS magnitude.
- Added Float support for MatrixDenseBLAS matrix-vector and matrix-matrix multiplication.
- Added Float tests for scalar, vector, matrix, and tensor operations.
- Added Float vs Double benchmark coverage for representative vector, matrix, and tensor workloads.