### PR TITLE
Add Complex<Float> scalar support

### DIFF
--- a/Sources/AccelerateWrapper/AccelerateOperations.swift
+++ b/Sources/AccelerateWrapper/AccelerateOperations.swift
@@ -64,6 +64,32 @@ public struct AccelerateOperations {
         }
     }
 
+    public static func cgemv(_ m: Int32, _ n: Int32, _ a: inout [Float], _ x: inout [Float], _ y: inout [Float]) {
+        var alpha: [Float] = [1.0, 0.0]
+        var beta: [Float] = [0.0, 0.0]
+        let lda = Int32(m)
+        let incx = Int32(1)
+        let incy = Int32(1)
+        alpha.withUnsafeMutableBufferPointer { alpha in
+            beta.withUnsafeMutableBufferPointer { beta in
+                a.withUnsafeMutableBufferPointer { a in
+                    x.withUnsafeMutableBufferPointer { x in
+                        y.withUnsafeMutableBufferPointer { y in
+                            Accelerate.cblas_cgemv(
+                                CblasColMajor, CblasNoTrans, m, n,
+                                OpaquePointer(UnsafeMutableRawPointer(alpha.baseAddress!)),
+                                OpaquePointer(UnsafeMutableRawPointer(a.baseAddress!)), lda,
+                                OpaquePointer(UnsafeMutableRawPointer(x.baseAddress!)), incx,
+                                OpaquePointer(UnsafeMutableRawPointer(beta.baseAddress!)),
+                                OpaquePointer(UnsafeMutableRawPointer(y.baseAddress!)), incy
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     public static func dgemm(
         _ m: Int32, _ n: Int32, _ k: Int32, _ a: [Double], _ b: [Double], _ c: inout [Double]
     ) {
@@ -132,6 +158,34 @@ public struct AccelerateOperations {
         }
     }
 
+    public static func cgemm(
+        _ m: Int32, _ n: Int32, _ k: Int32, _ a: inout [Float], _ b: inout [Float], _ c: inout [Float]
+    ) {
+        var alpha: [Float] = [1.0, 0.0]
+        var beta: [Float] = [0.0, 0.0]
+        let lda = m
+        let ldb = k
+        let ldc = m
+        alpha.withUnsafeMutableBufferPointer { alpha in
+            beta.withUnsafeMutableBufferPointer { beta in
+                a.withUnsafeMutableBufferPointer { a in
+                    b.withUnsafeMutableBufferPointer { b in
+                        c.withUnsafeMutableBufferPointer { c in
+                            Accelerate.cblas_cgemm(
+                                CblasColMajor, CblasNoTrans, CblasNoTrans, m, n, k,
+                                OpaquePointer(UnsafeMutableRawPointer(alpha.baseAddress!)),
+                                OpaquePointer(UnsafeMutableRawPointer(a.baseAddress!)), lda,
+                                OpaquePointer(UnsafeMutableRawPointer(b.baseAddress!)), ldb,
+                                OpaquePointer(UnsafeMutableRawPointer(beta.baseAddress!)),
+                                OpaquePointer(UnsafeMutableRawPointer(c.baseAddress!)), ldc
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     public static func daxpy(_ n: Int32, _ x: [Double], _ y: inout [Double]) {
         let alpha = 1.0
         let inc = Int32(1)
@@ -176,6 +230,20 @@ public struct AccelerateOperations {
         }
     }
 
+    public static func dznrm2(_ n: Int32, _ x: inout [Double]) -> Double {
+        let inc = Int32(1)
+        return x.withUnsafeMutableBufferPointer { x in
+            Accelerate.cblas_dznrm2(n, OpaquePointer(UnsafeMutableRawPointer(x.baseAddress!)), inc)
+        }
+    }
+
+    public static func scnrm2(_ n: Int32, _ x: inout [Float]) -> Float {
+        let inc = Int32(1)
+        return x.withUnsafeMutableBufferPointer { x in
+            Accelerate.cblas_scnrm2(n, OpaquePointer(UnsafeMutableRawPointer(x.baseAddress!)), inc)
+        }
+    }
+
     public static func zaxpy(_ n: Int32, _ x: inout [Double], _ y: inout [Double]) {
         var alpha = [1.0, 0.0]
         let inc = Int32(1)
@@ -206,9 +274,38 @@ public struct AccelerateOperations {
         }
     }
 
-    public static func dgesv(
-        _ n: Int32, _ a: UnsafeMutablePointer<Double>, _ b: UnsafeMutablePointer<Double>
-    ) -> Int32 {
+    public static func caxpy(_ n: Int32, _ x: inout [Float], _ y: inout [Float]) {
+        var alpha: [Float] = [1.0, 0.0]
+        let inc = Int32(1)
+        alpha.withUnsafeMutableBufferPointer { alpha in
+            x.withUnsafeMutableBufferPointer { x in
+                y.withUnsafeMutableBufferPointer { y in
+                    Accelerate.cblas_caxpy(
+                        n,
+                        OpaquePointer(UnsafeMutableRawPointer(alpha.baseAddress!)),
+                        OpaquePointer(UnsafeMutableRawPointer(x.baseAddress!)), inc,
+                        OpaquePointer(UnsafeMutableRawPointer(y.baseAddress!)), inc
+                    )
+                }
+            }
+        }
+    }
+
+    public static func cscal(_ n: Int32, _ alpha: inout [Float], _ x: inout [Float]) {
+        let inc = Int32(1)
+        alpha.withUnsafeMutableBufferPointer { alpha in
+            x.withUnsafeMutableBufferPointer { x in
+                Accelerate.cblas_cscal(
+                    n,
+                    OpaquePointer(UnsafeMutableRawPointer(alpha.baseAddress!)),
+                    OpaquePointer(UnsafeMutableRawPointer(x.baseAddress!)), inc
+                )
+            }
+        }
+    }
+
+    public static func dgesv(_ n: Int32, _ a: UnsafeMutablePointer<Double>, _ b: UnsafeMutablePointer<Double>)
+        -> Int32 {
         var nMutable = n
         var nrhs = Int32(1)
         var lda = n

--- a/Sources/LinearSolvers/DenseLinearSolvers.swift
+++ b/Sources/LinearSolvers/DenseLinearSolvers.swift
@@ -24,19 +24,19 @@ public func solveLinearDense<M: PluMatrix, V: PluVector>(_ A: M, _ b: V, blasImp
             let _ = OpenBLASOperations.dgesv(Int32(n), &AArray, &bArray)
             x = bArray as! [V.S]
         }
-    case is Complex.Type:
-        var AArray = interleaved(A.flatten() as! [Complex])
-        var bArray = interleaved(b.toArray() as! [Complex])
+    case is ComplexDouble.Type:
+        var AArray = BLASComplexStorage.interleaved(A.flatten() as! [ComplexDouble])
+        var bArray = BLASComplexStorage.interleaved(b.toArray() as! [ComplexDouble])
 
         switch blasImplementation {
         #if canImport(Accelerate)
         case .accelerate:
             let _ = AccelerateOperations.zgesv(Int32(n), &AArray, &bArray)
-            x = complexValues(bArray) as! [V.S]
+            x = BLASComplexStorage.complexValues(bArray) as! [V.S]
         #endif
         case .openBLAS:
             let _ = OpenBLASOperations.zgesv(Int32(n), &AArray, &bArray)
-            x = complexValues(bArray) as! [V.S]
+            x = BLASComplexStorage.complexValues(bArray) as! [V.S]
         }
 
     default:
@@ -44,12 +44,4 @@ public func solveLinearDense<M: PluMatrix, V: PluVector>(_ A: M, _ b: V, blasImp
     }
 
     return V(x)
-}
-
-private func interleaved(_ values: [Complex]) -> [Double] {
-    values.flatMap { [$0.real, $0.imaginary] }
-}
-
-private func complexValues(_ values: [Double]) -> [Complex] {
-    stride(from: 0, to: values.count, by: 2).map { Complex(values[$0], values[$0 + 1]) }
 }

--- a/Sources/OpenBLASWrapper/OpenBLASOperations.swift
+++ b/Sources/OpenBLASWrapper/OpenBLASOperations.swift
@@ -60,6 +60,29 @@ public enum OpenBLASOperations {
         }
     }
 
+    public static func cgemv(_ m: Int32, _ n: Int32, _ a: inout [Float], _ x: inout [Float], _ y: inout [Float]) {
+        var alpha: [Float] = [1.0, 0.0]
+        var beta: [Float] = [0.0, 0.0]
+        let lda = Int32(m)
+        let incx = Int32(1)
+        let incy = Int32(1)
+        alpha.withUnsafeMutableBufferPointer { alpha in
+            beta.withUnsafeMutableBufferPointer { beta in
+                a.withUnsafeMutableBufferPointer { a in
+                    x.withUnsafeMutableBufferPointer { x in
+                        y.withUnsafeMutableBufferPointer { y in
+                            COpenBLAS.cblas_cgemv(
+                                CblasColMajor, CblasNoTrans, m, n,
+                                alpha.baseAddress, a.baseAddress, lda, x.baseAddress, incx,
+                                beta.baseAddress, y.baseAddress, incy
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     public static func dgemm(
         _ m: Int32, _ n: Int32, _ k: Int32, _ a: [Double], _ b: [Double], _ c: inout [Double]
     ) {
@@ -125,6 +148,31 @@ public enum OpenBLASOperations {
         }
     }
 
+    public static func cgemm(
+        _ m: Int32, _ n: Int32, _ k: Int32, _ a: inout [Float], _ b: inout [Float], _ c: inout [Float]
+    ) {
+        var alpha: [Float] = [1.0, 0.0]
+        var beta: [Float] = [0.0, 0.0]
+        let lda = m
+        let ldb = k
+        let ldc = m
+        alpha.withUnsafeMutableBufferPointer { alpha in
+            beta.withUnsafeMutableBufferPointer { beta in
+                a.withUnsafeMutableBufferPointer { a in
+                    b.withUnsafeMutableBufferPointer { b in
+                        c.withUnsafeMutableBufferPointer { c in
+                            COpenBLAS.cblas_cgemm(
+                                CblasColMajor, CblasNoTrans, CblasNoTrans, m, n, k,
+                                alpha.baseAddress, a.baseAddress, lda, b.baseAddress, ldb,
+                                beta.baseAddress, c.baseAddress, ldc
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     public static func daxpy(_ n: Int32, _ x: [Double], _ y: inout [Double]) {
         let alpha = 1.0
         let inc = Int32(1)
@@ -169,6 +217,20 @@ public enum OpenBLASOperations {
         }
     }
 
+    public static func dznrm2(_ n: Int32, _ x: inout [Double]) -> Double {
+        let inc = Int32(1)
+        return x.withUnsafeMutableBufferPointer { x in
+            COpenBLAS.cblas_dznrm2(n, x.baseAddress, inc)
+        }
+    }
+
+    public static func scnrm2(_ n: Int32, _ x: inout [Float]) -> Float {
+        let inc = Int32(1)
+        return x.withUnsafeMutableBufferPointer { x in
+            COpenBLAS.cblas_scnrm2(n, x.baseAddress, inc)
+        }
+    }
+
     public static func zaxpy(_ n: Int32, _ x: inout [Double], _ y: inout [Double]) {
         var alpha = [1.0, 0.0]
         let inc = Int32(1)
@@ -190,9 +252,29 @@ public enum OpenBLASOperations {
         }
     }
 
-    public static func dgesv(
-        _ n: Int32, _ a: UnsafeMutablePointer<Double>, _ b: UnsafeMutablePointer<Double>
-    ) -> Int32 {
+    public static func caxpy(_ n: Int32, _ x: inout [Float], _ y: inout [Float]) {
+        var alpha: [Float] = [1.0, 0.0]
+        let inc = Int32(1)
+        alpha.withUnsafeMutableBufferPointer { alpha in
+            x.withUnsafeMutableBufferPointer { x in
+                y.withUnsafeMutableBufferPointer { y in
+                    COpenBLAS.cblas_caxpy(n, alpha.baseAddress, x.baseAddress, inc, y.baseAddress, inc)
+                }
+            }
+        }
+    }
+
+    public static func cscal(_ n: Int32, _ alpha: inout [Float], _ x: inout [Float]) {
+        let inc = Int32(1)
+        alpha.withUnsafeMutableBufferPointer { alpha in
+            x.withUnsafeMutableBufferPointer { x in
+                COpenBLAS.cblas_cscal(n, alpha.baseAddress, x.baseAddress, inc)
+            }
+        }
+    }
+
+    public static func dgesv(_ n: Int32, _ a: UnsafeMutablePointer<Double>, _ b: UnsafeMutablePointer<Double>)
+        -> Int32 {
         var nMutable = n
         var nrhs = Int32(1)
         var lda = n

--- a/Sources/PlumeriaBenchmarks/main.swift
+++ b/Sources/PlumeriaBenchmarks/main.swift
@@ -40,6 +40,18 @@ func compareFloatBenchmark(
     return doubleChecksum + floatChecksum
 }
 
+func compareComplexFloatBenchmark(
+    _ operation: String, _ size: String, samples: Int = 5, iterations: Int = 1,
+    complex: () -> Double, complexFloat: () -> Double
+) -> Double {
+    let (complexResult, complexChecksum) = measure(samples: samples, iterations: iterations, operation: complex)
+    let (complexFloatResult, complexFloatChecksum) = measure(
+        samples: samples, iterations: iterations, operation: complexFloat
+    )
+    printComplexFloatBenchmark(operation, size, complex: complexResult, complexFloat: complexFloatResult)
+    return complexChecksum + complexFloatChecksum
+}
+
 func summarize(_ values: [Double]) -> TimedResult {
     let sorted = values.sorted()
     return TimedResult(best: sorted[0], median: sorted[sorted.count / 2])
@@ -65,6 +77,14 @@ func printFloatBenchmark(_ operation: String, _ size: String, double: TimedResul
     print("")
 }
 
+func printComplexFloatBenchmark(_ operation: String, _ size: String, complex: TimedResult, complexFloat: TimedResult) {
+    print("  \(operation) \(size)")
+    print("    Complex:  median \(format(complex.median)) ms, best \(format(complex.best)) ms")
+    print("    ComplexF: median \(format(complexFloat.median)) ms, best \(format(complexFloat.best)) ms")
+    print("    ratio:    \(ratio(left: complex.median, "Complex", right: complexFloat.median, "ComplexF"))")
+    print("")
+}
+
 func ratio(reference: Double, blas: Double) -> String {
     if reference == 0 && blas == 0 { return "same speed" }
     if reference == 0 { return "reference faster" }
@@ -83,6 +103,16 @@ func ratio(double: Double, float: Double) -> String {
         return "Double \(format(float / double))x faster"
     }
     return "Float \(format(double / float))x faster"
+}
+
+func ratio(left: Double, _ leftLabel: String, right: Double, _ rightLabel: String) -> String {
+    if left == 0 && right == 0 { return "same speed" }
+    if left == 0 { return "\(leftLabel) faster" }
+    if right == 0 { return "\(rightLabel) faster" }
+    if left < right {
+        return "\(leftLabel) \(format(right / left))x faster"
+    }
+    return "\(rightLabel) \(format(left / right))x faster"
 }
 
 func commandOutput(_ command: String, _ arguments: [String]) -> String {
@@ -110,6 +140,14 @@ func vectorFloatValues(count: Int) -> [Float] {
     vectorValues(count: count).map(Float.init)
 }
 
+func vectorComplexValues(count: Int) -> [ComplexDouble] {
+    vectorValues(count: count).map { ComplexDouble($0, -$0 / 2.0) }
+}
+
+func vectorComplexFloatValues(count: Int) -> [ComplexFloat] {
+    vectorValues(count: count).map { ComplexFloat(Float($0), Float(-$0 / 2.0)) }
+}
+
 func matrixRows(rows: Int, columns: Int) -> [[Double]] {
     var values: [[Double]] = []
     values.reserveCapacity(rows)
@@ -128,6 +166,14 @@ func matrixFloatRows(rows: Int, columns: Int) -> [[Float]] {
     matrixRows(rows: rows, columns: columns).map { $0.map(Float.init) }
 }
 
+func matrixComplexRows(rows: Int, columns: Int) -> [[ComplexDouble]] {
+    matrixRows(rows: rows, columns: columns).map { row in row.map { ComplexDouble($0, -$0 / 3.0) } }
+}
+
+func matrixComplexFloatRows(rows: Int, columns: Int) -> [[ComplexFloat]] {
+    matrixRows(rows: rows, columns: columns).map { row in row.map { ComplexFloat(Float($0), Float(-$0 / 3.0)) } }
+}
+
 func fillTensor<T: TensorMultiplication>(_ tensor: inout T) where T.S == Double {
     for index in indexCombinations(for: tensor.shape) {
         let weighted = index.enumerated().reduce(0) { $0 + ($1.offset + 1) * ($1.element + 1) }
@@ -139,6 +185,22 @@ func fillFloatTensor<T: TensorMultiplication>(_ tensor: inout T) where T.S == Fl
     for index in indexCombinations(for: tensor.shape) {
         let weighted = index.enumerated().reduce(0) { $0 + ($1.offset + 1) * ($1.element + 1) }
         tensor[index] = Float((weighted % 29) - 14) / 5.0
+    }
+}
+
+func fillComplexTensor<T: TensorMultiplication>(_ tensor: inout T) where T.S == ComplexDouble {
+    for index in indexCombinations(for: tensor.shape) {
+        let weighted = index.enumerated().reduce(0) { $0 + ($1.offset + 1) * ($1.element + 1) }
+        let value = Double((weighted % 29) - 14) / 5.0
+        tensor[index] = ComplexDouble(value, -value / 2.0)
+    }
+}
+
+func fillComplexFloatTensor<T: TensorMultiplication>(_ tensor: inout T) where T.S == ComplexFloat {
+    for index in indexCombinations(for: tensor.shape) {
+        let weighted = index.enumerated().reduce(0) { $0 + ($1.offset + 1) * ($1.element + 1) }
+        let value = Float((weighted % 29) - 14) / 5.0
+        tensor[index] = ComplexFloat(value, -value / 2.0)
     }
 }
 
@@ -357,6 +419,63 @@ func benchmarkFloatScalars() -> Double {
     return checksum
 }
 
+func benchmarkComplexFloatScalars() -> Double {
+    print("ComplexF vs Complex")
+    let complexVector = VectorDenseBLAS(vectorComplexValues(count: 100_000))
+    let complexFloatVector = VectorDenseBLAS(vectorComplexFloatValues(count: 100_000))
+    let complexMatrixVector = VectorDenseBLAS(vectorComplexValues(count: 384))
+    let complexFloatMatrixVector = VectorDenseBLAS(vectorComplexFloatValues(count: 384))
+    let complexMatrix = MatrixDenseBLAS(matrixComplexRows(rows: 384, columns: 384))
+    let complexFloatMatrix = MatrixDenseBLAS(matrixComplexFloatRows(rows: 384, columns: 384))
+    let complexLeftMatrix = MatrixDenseBLAS(matrixComplexRows(rows: 128, columns: 128))
+    let complexRightMatrix = MatrixDenseBLAS(matrixComplexRows(rows: 128, columns: 128))
+    let complexFloatLeftMatrix = MatrixDenseBLAS(matrixComplexFloatRows(rows: 128, columns: 128))
+    let complexFloatRightMatrix = MatrixDenseBLAS(matrixComplexFloatRows(rows: 128, columns: 128))
+    var complexTensor = TensorDenseBLAS<ComplexDouble>(shape: [16, 24, 16], initialValue: .zero)
+    var complexRightTensor = TensorDenseBLAS<ComplexDouble>(shape: [16, 16], initialValue: .zero)
+    var complexFloatTensor = TensorDenseBLAS<ComplexFloat>(shape: [16, 24, 16], initialValue: .zero)
+    var complexFloatRightTensor = TensorDenseBLAS<ComplexFloat>(shape: [16, 16], initialValue: .zero)
+    fillComplexTensor(&complexTensor)
+    fillComplexTensor(&complexRightTensor)
+    fillComplexFloatTensor(&complexFloatTensor)
+    fillComplexFloatTensor(&complexFloatRightTensor)
+    var checksum = 0.0
+    checksum += compareComplexFloatBenchmark("vector add", "100,000", iterations: 10, complex: {
+        let result = complexVector + complexVector
+        return result[0].real + result[result.size - 1].real
+    }, complexFloat: {
+        let result = complexFloatVector + complexFloatVector
+        return Double(result[0].real + result[result.size - 1].real)
+    })
+    checksum += compareComplexFloatBenchmark("magnitude", "100,000", iterations: 10, complex: {
+        complexVector.magnitude()
+    }, complexFloat: {
+        Double(complexFloatVector.magnitude())
+    })
+    checksum += compareComplexFloatBenchmark("matrix-vector multiply", "384x384", complex: {
+        let result = complexMatrix * complexMatrixVector
+        return result[0].real + result[result.size - 1].real
+    }, complexFloat: {
+        let result = complexFloatMatrix * complexFloatMatrixVector
+        return Double(result[0].real + result[result.size - 1].real)
+    })
+    checksum += compareComplexFloatBenchmark("matrix-matrix multiply", "128x128", complex: {
+        let result = complexLeftMatrix * complexRightMatrix
+        return result[0, 0].real + result[result.rows - 1, result.columns - 1].real
+    }, complexFloat: {
+        let result = complexFloatLeftMatrix * complexFloatRightMatrix
+        return Double(result[0, 0].real + result[result.rows - 1, result.columns - 1].real)
+    })
+    checksum += compareComplexFloatBenchmark("tensor contraction", "16x24x16,16x16", complex: {
+        let result = multiply(complexTensor, ["i", "j", "k"], complexRightTensor, ["k", "l"])
+        return result[[0, 0, 0]].real + result[[15, 23, 15]].real
+    }, complexFloat: {
+        let result = multiply(complexFloatTensor, ["i", "j", "k"], complexFloatRightTensor, ["k", "l"])
+        return Double(result[[0, 0, 0]].real + result[[15, 23, 15]].real)
+    })
+    return checksum
+}
+
 let swiftVersion = commandOutput("/usr/bin/env", ["swift", "--version"])
 let platform = commandOutput("/usr/bin/env", ["uname", "-m"])
 
@@ -364,5 +483,6 @@ print("PlumeriaBenchmarks")
 print("Swift: \(swiftVersion)")
 print("Platform: \(platform)")
 print("")
-let blackHole = benchmarkVectors() + benchmarkMatrices() + benchmarkTensors() + benchmarkFloatScalars()
+let blackHole = benchmarkVectors() + benchmarkMatrices() + benchmarkTensors()
+    + benchmarkFloatScalars() + benchmarkComplexFloatScalars()
 print("Checksum: \(blackHole)")

--- a/Sources/Tensors/BLAS.swift
+++ b/Sources/Tensors/BLAS.swift
@@ -64,4 +64,20 @@ public enum BLAS {
         OpenBLASOperations.zscal(n, &alpha, &x)
         #endif
     }
+
+    static func caxpy(_ n: Int32, _ x: inout [Float], _ y: inout [Float]) {
+        #if canImport(Accelerate)
+        AccelerateOperations.caxpy(n, &x, &y)
+        #else
+        OpenBLASOperations.caxpy(n, &x, &y)
+        #endif
+    }
+
+    static func cscal(_ n: Int32, _ alpha: inout [Float], _ x: inout [Float]) {
+        #if canImport(Accelerate)
+        AccelerateOperations.cscal(n, &alpha, &x)
+        #else
+        OpenBLASOperations.cscal(n, &alpha, &x)
+        #endif
+    }
 }

--- a/Sources/Tensors/BLASComplexStorage.swift
+++ b/Sources/Tensors/BLASComplexStorage.swift
@@ -1,0 +1,11 @@
+import Numerics
+
+public enum BLASComplexStorage {
+    public static func interleaved<RealType: Real>(_ values: [Numerics.Complex<RealType>]) -> [RealType] {
+        values.flatMap { [$0.real, $0.imaginary] }
+    }
+
+    public static func complexValues<RealType: Real>(_ values: [RealType]) -> [Numerics.Complex<RealType>] {
+        stride(from: 0, to: values.count, by: 2).map { Numerics.Complex(values[$0], values[$0 + 1]) }
+    }
+}

--- a/Sources/Tensors/Core/PluScalar.swift
+++ b/Sources/Tensors/Core/PluScalar.swift
@@ -1,7 +1,8 @@
 import Foundation
 import Numerics
 
-public typealias Complex = Numerics.Complex<Double>
+public typealias ComplexDouble = Numerics.Complex<Double>
+public typealias ComplexFloat = Numerics.Complex<Float>
 
 public protocol PluScalar: ElementaryFunctions & PluTensor & Numeric where Magnitude: FloatingPoint {
     static func / (lhs: Self, rhs: Self) -> Self
@@ -32,56 +33,49 @@ extension Float: PluScalar {
     }
 }
 
-extension Complex: TensorArithmetic, PluTensor, PluScalar {
-    public typealias S = Complex
+extension Numerics.Complex: TensorArithmetic, PluTensor, PluScalar {
+    public typealias S = Numerics.Complex<RealType>
 
-    public static let i = Complex(0.0, 1.0)
+    public static var i: Self { Self(RealType(0), RealType(1)) }
 
-    public func round(precision: Int = 14) -> Complex {
-        return Complex(real.round(precision: precision), imaginary.round(precision: precision))
+    public func round(precision: Int) -> Self {
+        let multiplier = RealType.pow(RealType(10), RealType(precision))
+        return Self((real * multiplier).rounded() / multiplier,
+                    (imaginary * multiplier).rounded() / multiplier)
     }
 }
 
-extension Complex: ComplexScalar {
-    public var star: Complex { conjugate }
-    public var mod: Double { length }
-    public var arg: Double { phase }
+extension Numerics.Complex: ComplexScalar {
+    public var star: Self { conjugate }
+    public var mod: RealType { length }
+    public var arg: RealType { phase }
 }
 
-public func + (left: Double, right: Complex) -> Complex {
-    Complex(left, 0.0) + right
-}
+public func + (left: Double, right: ComplexDouble) -> ComplexDouble { ComplexDouble(left, 0.0) + right }
+public func + (left: ComplexDouble, right: Double) -> ComplexDouble { left + ComplexDouble(right, 0.0) }
+public func - (left: Double, right: ComplexDouble) -> ComplexDouble { ComplexDouble(left, 0.0) - right }
+public func - (left: ComplexDouble, right: Double) -> ComplexDouble { left - ComplexDouble(right, 0.0) }
+public func * (left: Double, right: ComplexDouble) -> ComplexDouble { ComplexDouble(left, 0.0) * right }
+public func * (left: ComplexDouble, right: Double) -> ComplexDouble { left * ComplexDouble(right, 0.0) }
+public func / (left: Double, right: ComplexDouble) -> ComplexDouble { ComplexDouble(left, 0.0) / right }
+public func / (left: ComplexDouble, right: Double) -> ComplexDouble { left / ComplexDouble(right, 0.0) }
 
-public func + (left: Complex, right: Double) -> Complex {
-    left + Complex(right, 0.0)
-}
-
-public func - (left: Double, right: Complex) -> Complex {
-    Complex(left, 0.0) - right
-}
-
-public func - (left: Complex, right: Double) -> Complex {
-    left - Complex(right, 0.0)
-}
-
-public func * (left: Double, right: Complex) -> Complex {
-    Complex(left, 0.0) * right
-}
-
-public func * (left: Complex, right: Double) -> Complex {
-    left * Complex(right, 0.0)
-}
-
-public func / (left: Double, right: Complex) -> Complex {
-    Complex(left, 0.0) / right
-}
-
-public func / (left: Complex, right: Double) -> Complex {
-    left / Complex(right, 0.0)
-}
+public func + (left: Float, right: ComplexFloat) -> ComplexFloat { ComplexFloat(left, 0.0) + right }
+public func + (left: ComplexFloat, right: Float) -> ComplexFloat { left + ComplexFloat(right, 0.0) }
+public func - (left: Float, right: ComplexFloat) -> ComplexFloat { ComplexFloat(left, 0.0) - right }
+public func - (left: ComplexFloat, right: Float) -> ComplexFloat { left - ComplexFloat(right, 0.0) }
+public func * (left: Float, right: ComplexFloat) -> ComplexFloat { ComplexFloat(left, 0.0) * right }
+public func * (left: ComplexFloat, right: Float) -> ComplexFloat { left * ComplexFloat(right, 0.0) }
+public func / (left: Float, right: ComplexFloat) -> ComplexFloat { ComplexFloat(left, 0.0) / right }
+public func / (left: ComplexFloat, right: Float) -> ComplexFloat { left / ComplexFloat(right, 0.0) }
 
 extension PluScalar {
     public func round() -> Self {
-        round(precision: 14)
+        switch Self.self {
+        case is Float.Type, is ComplexFloat.Type:
+            return round(precision: 6)
+        default:
+            return round(precision: 14)
+        }
     }
 }

--- a/Sources/Tensors/Matrix/Eigen.swift
+++ b/Sources/Tensors/Matrix/Eigen.swift
@@ -1,8 +1,8 @@
-public struct Eigen<Vectors: PluMatrix>: Equatable where Vectors.S == Complex {
-    public let values: [Complex]
+public struct Eigen<Value: ComplexScalar, Vectors: PluMatrix>: Equatable where Vectors.S == Value {
+    public let values: [Value]
     public let vectors: Vectors
 
-    public init(values: [Complex], vectors: Vectors) {
+    public init(values: [Value], vectors: Vectors) {
         self.values = values
         self.vectors = vectors
     }

--- a/Sources/Tensors/Matrix/MatrixDenseBLAS.swift
+++ b/Sources/Tensors/Matrix/MatrixDenseBLAS.swift
@@ -1,4 +1,5 @@
 import AccelerateWrapper
+import Numerics
 import OpenBLASWrapper
 
 // Usage of MatrixArithmeticReference is temporary until determinant and inverse use LAPACK.
@@ -191,9 +192,9 @@ extension MatrixDenseBLAS {
                 OpenBLASOperations.sgemv(Int32(rows), Int32(columns), A, x, &y)
             }
             return V(y as! [S])
-        case is Complex.Type:
-            var A = MatrixDenseBLAS.interleaved(flatten() as! [Complex])
-            var x = MatrixDenseBLAS.interleaved(v.toArray(round: false) as! [Complex])
+        case is ComplexDouble.Type:
+            var A = BLASComplexStorage.interleaved(flatten() as! [ComplexDouble])
+            var x = BLASComplexStorage.interleaved(v.toArray(round: false) as! [ComplexDouble])
             var y = Array(repeating: 0.0, count: rows * 2)
             switch blasImplementation {
             #if canImport(Accelerate)
@@ -203,7 +204,20 @@ extension MatrixDenseBLAS {
             case .openBLAS:
                 OpenBLASOperations.zgemv(Int32(rows), Int32(columns), &A, &x, &y)
             }
-            return V(MatrixDenseBLAS.complexValues(y) as! [S])
+            return V(BLASComplexStorage.complexValues(y) as! [S])
+        case is ComplexFloat.Type:
+            var A = BLASComplexStorage.interleaved(flatten() as! [ComplexFloat])
+            var x = BLASComplexStorage.interleaved(v.toArray(round: false) as! [ComplexFloat])
+            var y = Array(repeating: Float.zero, count: rows * 2)
+            switch blasImplementation {
+            #if canImport(Accelerate)
+            case .accelerate:
+                AccelerateOperations.cgemv(Int32(rows), Int32(columns), &A, &x, &y)
+            #endif
+            case .openBLAS:
+                OpenBLASOperations.cgemv(Int32(rows), Int32(columns), &A, &x, &y)
+            }
+            return V(BLASComplexStorage.complexValues(y) as! [S])
         default:
             fatalError("Unsupported scalar type")
         }
@@ -238,9 +252,9 @@ extension MatrixDenseBLAS {
                 OpenBLASOperations.sgemm(Int32(rows), Int32(m.columns), Int32(columns), A, B, &C)
             }
             return MatrixDenseBLAS(rows: rows, columns: m.columns, values: C as! [S])
-        case is Complex.Type:
-            var A = MatrixDenseBLAS.interleaved(flatten() as! [Complex])
-            var B = MatrixDenseBLAS.interleaved(m.flatten() as! [Complex])
+        case is ComplexDouble.Type:
+            var A = BLASComplexStorage.interleaved(flatten() as! [ComplexDouble])
+            var B = BLASComplexStorage.interleaved(m.flatten() as! [ComplexDouble])
             var C = Array(repeating: 0.0, count: rows * m.columns * 2)
             switch blasImplementation {
             #if canImport(Accelerate)
@@ -250,7 +264,21 @@ extension MatrixDenseBLAS {
             case .openBLAS:
                 OpenBLASOperations.zgemm(Int32(rows), Int32(m.columns), Int32(columns), &A, &B, &C)
             }
-            return MatrixDenseBLAS(rows: rows, columns: m.columns, values: MatrixDenseBLAS.complexValues(C) as! [S])
+            return MatrixDenseBLAS(rows: rows, columns: m.columns, values: BLASComplexStorage.complexValues(C) as! [S])
+        case is ComplexFloat.Type:
+            var A = BLASComplexStorage.interleaved(flatten() as! [ComplexFloat])
+            var B = BLASComplexStorage.interleaved(m.flatten() as! [ComplexFloat])
+            var C = Array(repeating: Float.zero, count: rows * m.columns * 2)
+            switch blasImplementation {
+            #if canImport(Accelerate)
+            case .accelerate:
+                AccelerateOperations.cgemm(Int32(rows), Int32(m.columns), Int32(columns), &A, &B, &C)
+            #endif
+            case .openBLAS:
+                OpenBLASOperations.cgemm(Int32(rows), Int32(m.columns), Int32(columns), &A, &B, &C)
+            }
+            let values = BLASComplexStorage.complexValues(C) as! [S]
+            return MatrixDenseBLAS(rows: rows, columns: m.columns, values: values)
         default:
             fatalError("Unsupported scalar type")
         }
@@ -304,20 +332,13 @@ extension MatrixDenseBLAS {
         return matrix.flatten(columnMajorOrder: true)
     }
 
-    private static func interleaved(_ values: [Complex]) -> [Double] {
-        values.flatMap { [$0.real, $0.imaginary] }
-    }
-
-    private static func complexValues(_ values: [Double]) -> [Complex] {
-        stride(from: 0, to: values.count, by: 2).map { Complex(values[$0], values[$0 + 1]) }
-    }
-
 }
 
 extension MatrixDenseBLAS: MatrixEigen where S == Double {
-    public typealias Eigenvectors = MatrixDenseBLAS<Complex>
+    public typealias Eigenvalue = ComplexDouble
+    public typealias Eigenvectors = MatrixDenseBLAS<ComplexDouble>
 
-    public func eigen() -> Eigen<MatrixDenseBLAS<Complex>> {
+    public func eigen() -> Eigen<ComplexDouble, MatrixDenseBLAS<ComplexDouble>> {
         precondition(rows == columns, "Eigen decomposition requires a square matrix")
         let n = Int32(rows)
         var matrix = flatten()
@@ -334,25 +355,27 @@ extension MatrixDenseBLAS: MatrixEigen where S == Double {
                      vectors: eigenvectors(real: real, imaginary: imaginary, vectors: vectors))
     }
 
-    private func eigenvalues(real: [Double], imaginary: [Double]) -> [Complex] {
-        zip(real, imaginary).map { Complex($0, $1) }
+    private func eigenvalues(real: [Double], imaginary: [Double]) -> [ComplexDouble] {
+        zip(real, imaginary).map { ComplexDouble($0, $1) }
     }
 
-    private func eigenvectors(real: [Double], imaginary: [Double], vectors: [Double]) -> MatrixDenseBLAS<Complex> {
-        var result = MatrixDenseBLAS<Complex>(rows: rows, columns: columns, initialValue: .zero)
+    private func eigenvectors(
+        real: [Double], imaginary: [Double], vectors: [Double]
+    ) -> MatrixDenseBLAS<ComplexDouble> {
+        var result = MatrixDenseBLAS<ComplexDouble>(rows: rows, columns: columns, initialValue: .zero)
         var column = 0
         while column < columns {
             if imaginary[column] == 0.0 {
                 for row in 0..<rows {
-                    result[row, column] = Complex(vectors[row + rows * column], 0.0)
+                    result[row, column] = ComplexDouble(vectors[row + rows * column], 0.0)
                 }
                 column += 1
             } else {
                 for row in 0..<rows {
                     let realPart = vectors[row + rows * column]
                     let imaginaryPart = vectors[row + rows * (column + 1)]
-                    result[row, column] = Complex(realPart, imaginaryPart)
-                    result[row, column + 1] = Complex(realPart, -imaginaryPart)
+                    result[row, column] = ComplexDouble(realPart, imaginaryPart)
+                    result[row, column + 1] = ComplexDouble(realPart, -imaginaryPart)
                 }
                 column += 2
             }

--- a/Sources/Tensors/Matrix/MatrixDenseReference.swift
+++ b/Sources/Tensors/Matrix/MatrixDenseReference.swift
@@ -1,3 +1,5 @@
+import Numerics
+
 public struct MatrixDenseReference<S: PluScalar>: MatrixArithmeticReference, TensorArithmeticReference,
     MatrixColumnMajorInitializable {
     private var elements: [[S]]
@@ -75,7 +77,8 @@ extension MatrixDenseReference: PluMatrix {
 }
 
 extension MatrixDenseReference: MatrixEigen where S == Double {
-    public typealias Eigenvectors = MatrixDenseReference<Complex>
+    public typealias Eigenvalue = ComplexDouble
+    public typealias Eigenvectors = MatrixDenseReference<ComplexDouble>
 }
 
 extension MatrixDenseReference {

--- a/Sources/Tensors/Protocols/MatrixArithmeticReference.swift
+++ b/Sources/Tensors/Protocols/MatrixArithmeticReference.swift
@@ -64,14 +64,14 @@ extension MatrixArithmeticReference {
 }
 
 extension MatrixArithmeticReference where Self: MatrixEigen, S == Double {
-    public func eigen() -> Eigen<Eigenvectors> {
+    public func eigen() -> Eigen<Eigenvalue, Eigenvectors> where Eigenvalue == ComplexDouble {
         precondition(rows == columns, "Eigen decomposition requires a square matrix")
         if rows == 1 {
-            return Eigen(values: [Complex(self[0, 0], 0.0)], vectors: Eigenvectors([[Complex(1.0, 0.0)]]))
+            return Eigen(values: [ComplexDouble(self[0, 0], 0.0)], vectors: Eigenvectors([[ComplexDouble(1.0, 0.0)]]))
         }
         precondition(rows == 2, "Reference eigen decomposition currently supports 1x1 and 2x2 matrices")
-        let a = Complex(self[0, 0], 0.0), b = Complex(self[0, 1], 0.0)
-        let c = Complex(self[1, 0], 0.0), d = Complex(self[1, 1], 0.0)
+        let a = ComplexDouble(self[0, 0], 0.0), b = ComplexDouble(self[0, 1], 0.0)
+        let c = ComplexDouble(self[1, 0], 0.0), d = ComplexDouble(self[1, 1], 0.0)
         let trace = a + d
         let determinant = a * d - b * c
         let root = squareRoot(trace * trace - 4.0 * determinant)
@@ -81,25 +81,28 @@ extension MatrixArithmeticReference where Self: MatrixEigen, S == Double {
         return Eigen(values: values, vectors: Eigenvectors([[first[0], second[0]], [first[1], second[1]]]))
     }
 
-    private func eigenvector(a: Complex, b: Complex, c: Complex, d: Complex, value: Complex, fallbackColumn: Int)
-        -> [Complex] {
+    private func eigenvector(
+        a: ComplexDouble, b: ComplexDouble, c: ComplexDouble, d: ComplexDouble,
+        value: ComplexDouble, fallbackColumn: Int
+    ) -> [ComplexDouble] {
         let first = [b, value - a]
         if !isZero(first) { return first }
         let second = [value - d, c]
         if !isZero(second) { return second }
-        return fallbackColumn == 0 ? [Complex(1.0, 0.0), Complex(0.0, 0.0)] : [Complex(0.0, 0.0), Complex(1.0, 0.0)]
+        if fallbackColumn == 0 { return [ComplexDouble(1.0, 0.0), ComplexDouble(0.0, 0.0)] }
+        return [ComplexDouble(0.0, 0.0), ComplexDouble(1.0, 0.0)]
     }
 
-    private func isZero(_ vector: [Complex]) -> Bool {
+    private func isZero(_ vector: [ComplexDouble]) -> Bool {
         vector.allSatisfy { $0.length <= 1e-12 }
     }
 
-    private func squareRoot(_ value: Complex) -> Complex {
-        if value.imaginary == 0.0 && value.real >= 0.0 { return Complex(Foundation.sqrt(value.real), 0.0) }
+    private func squareRoot(_ value: ComplexDouble) -> ComplexDouble {
+        if value.imaginary == 0.0 && value.real >= 0.0 { return ComplexDouble(Foundation.sqrt(value.real), 0.0) }
         let length = value.length
         let real = Foundation.sqrt((length + value.real) / 2.0)
         let imaginarySign = value.imaginary < 0.0 ? -1.0 : 1.0
         let imaginary = imaginarySign * Foundation.sqrt((length - value.real) / 2.0)
-        return Complex(real, imaginary)
+        return ComplexDouble(real, imaginary)
     }
 }

--- a/Sources/Tensors/Protocols/MatrixEigen.swift
+++ b/Sources/Tensors/Protocols/MatrixEigen.swift
@@ -1,4 +1,5 @@
 public protocol MatrixEigen: PluMatrix where S == Double {
-    associatedtype Eigenvectors: PluMatrix where Eigenvectors.S == Complex
-    func eigen() -> Eigen<Eigenvectors>
+    associatedtype Eigenvalue: ComplexScalar
+    associatedtype Eigenvectors: PluMatrix where Eigenvectors.S == Eigenvalue
+    func eigen() -> Eigen<Eigenvalue, Eigenvectors>
 }

--- a/Sources/Tensors/Protocols/TensorArithmeticBLAS.swift
+++ b/Sources/Tensors/Protocols/TensorArithmeticBLAS.swift
@@ -1,3 +1,5 @@
+import Numerics
+
 public protocol TensorArithmeticBLAS: TensorArithmetic, TensorStructure where S: PluScalar {
     init(shape: [Int], initialValue: S)
     var elements: [S] { get set }
@@ -53,11 +55,16 @@ extension TensorArithmeticBLAS {
             var y = left as! [Float]
             BLAS.axpy(Int32(y.count), x, &y)
             return y as! [S]
-        case is Complex.Type:
-            var x = interleaved(right as! [Complex])
-            var y = interleaved(left as! [Complex])
+        case is ComplexDouble.Type:
+            var x = BLASComplexStorage.interleaved(right as! [ComplexDouble])
+            var y = BLASComplexStorage.interleaved(left as! [ComplexDouble])
             BLAS.zaxpy(Int32(right.count), &x, &y)
-            return complexValues(y) as! [S]
+            return BLASComplexStorage.complexValues(y) as! [S]
+        case is ComplexFloat.Type:
+            var x = BLASComplexStorage.interleaved(right as! [ComplexFloat])
+            var y = BLASComplexStorage.interleaved(left as! [ComplexFloat])
+            BLAS.caxpy(Int32(right.count), &x, &y)
+            return BLASComplexStorage.complexValues(y) as! [S]
         default:
             fatalError("Unsupported scalar type")
         }
@@ -73,21 +80,19 @@ extension TensorArithmeticBLAS {
             var result = values as! [Float]
             BLAS.scal(Int32(result.count), scalar as! Float, &result)
             return result as! [S]
-        case is Complex.Type:
-            var result = interleaved(values as! [Complex])
-            var alpha = interleaved([scalar as! Complex])
+        case is ComplexDouble.Type:
+            var result = BLASComplexStorage.interleaved(values as! [ComplexDouble])
+            var alpha = BLASComplexStorage.interleaved([scalar as! ComplexDouble])
             BLAS.zscal(Int32(values.count), &alpha, &result)
-            return complexValues(result) as! [S]
+            return BLASComplexStorage.complexValues(result) as! [S]
+        case is ComplexFloat.Type:
+            var result = BLASComplexStorage.interleaved(values as! [ComplexFloat])
+            var alpha = BLASComplexStorage.interleaved([scalar as! ComplexFloat])
+            BLAS.cscal(Int32(values.count), &alpha, &result)
+            return BLASComplexStorage.complexValues(result) as! [S]
         default:
             fatalError("Unsupported scalar type")
         }
     }
 
-    private static func interleaved(_ values: [Complex]) -> [Double] {
-        values.flatMap { [$0.real, $0.imaginary] }
-    }
-
-    private static func complexValues(_ values: [Double]) -> [Complex] {
-        stride(from: 0, to: values.count, by: 2).map { Complex(values[$0], values[$0 + 1]) }
-    }
 }

--- a/Sources/Tensors/Protocols/TensorMixedScalarArithmetic.swift
+++ b/Sources/Tensors/Protocols/TensorMixedScalarArithmetic.swift
@@ -1,3 +1,5 @@
+import Numerics
+
 private func mixedScalarIndexCombinations(for shape: [Int]) -> [[Int]] {
     if shape.isEmpty { return [[]] }
     if shape.contains(0) { return [] }
@@ -11,30 +13,30 @@ private func mixedScalarIndexCombinations(for shape: [Int]) -> [[Int]] {
     }
 }
 
-public func * <T: TensorArithmeticReference>(tensor: T, scalar: Complex) -> TensorDenseBLAS<Complex>
+public func * <T: TensorArithmeticReference>(tensor: T, scalar: ComplexDouble) -> TensorDenseBLAS<ComplexDouble>
     where T.S == Double {
-    var result = TensorDenseBLAS<Complex>(shape: tensor.shape, initialValue: .zero)
+    var result = TensorDenseBLAS<ComplexDouble>(shape: tensor.shape, initialValue: .zero)
     for index in mixedScalarIndexCombinations(for: tensor.shape) {
         result[index] = tensor[index] * scalar
     }
     return result
 }
 
-public func * <T: TensorArithmeticReference>(scalar: Complex, tensor: T) -> TensorDenseBLAS<Complex>
+public func * <T: TensorArithmeticReference>(scalar: ComplexDouble, tensor: T) -> TensorDenseBLAS<ComplexDouble>
     where T.S == Double {
     tensor * scalar
 }
 
-public func / <T: TensorArithmeticReference>(tensor: T, scalar: Complex) -> TensorDenseBLAS<Complex>
+public func / <T: TensorArithmeticReference>(tensor: T, scalar: ComplexDouble) -> TensorDenseBLAS<ComplexDouble>
     where T.S == Double {
-    var result = TensorDenseBLAS<Complex>(shape: tensor.shape, initialValue: .zero)
+    var result = TensorDenseBLAS<ComplexDouble>(shape: tensor.shape, initialValue: .zero)
     for index in mixedScalarIndexCombinations(for: tensor.shape) {
         result[index] = tensor[index] / scalar
     }
     return result
 }
 
-public func * <T: TensorArithmeticReference>(tensor: T, scalar: Double) -> T where T.S == Complex {
+public func * <T: TensorArithmeticReference>(tensor: T, scalar: Double) -> T where T.S == ComplexDouble {
     var result = T(shape: tensor.shape, initialValue: .zero)
     for index in mixedScalarIndexCombinations(for: tensor.shape) {
         result[index] = tensor[index] * scalar
@@ -42,11 +44,11 @@ public func * <T: TensorArithmeticReference>(tensor: T, scalar: Double) -> T whe
     return result
 }
 
-public func * <T: TensorArithmeticReference>(scalar: Double, tensor: T) -> T where T.S == Complex {
+public func * <T: TensorArithmeticReference>(scalar: Double, tensor: T) -> T where T.S == ComplexDouble {
     tensor * scalar
 }
 
-public func / <T: TensorArithmeticReference>(tensor: T, scalar: Double) -> T where T.S == Complex {
+public func / <T: TensorArithmeticReference>(tensor: T, scalar: Double) -> T where T.S == ComplexDouble {
     var result = T(shape: tensor.shape, initialValue: .zero)
     for index in mixedScalarIndexCombinations(for: tensor.shape) {
         result[index] = tensor[index] / scalar
@@ -54,26 +56,99 @@ public func / <T: TensorArithmeticReference>(tensor: T, scalar: Double) -> T whe
     return result
 }
 
-public func * <T: TensorArithmeticBLAS>(tensor: T, scalar: Complex) -> TensorDenseBLAS<Complex> where T.S == Double {
-    TensorDenseBLAS<Complex>(shape: tensor.shape, elements: tensor.elements.map { $0 * scalar })
+public func * <T: TensorArithmeticReference>(tensor: T, scalar: ComplexFloat) -> TensorDenseBLAS<ComplexFloat>
+    where T.S == Float {
+    var result = TensorDenseBLAS<ComplexFloat>(shape: tensor.shape, initialValue: .zero)
+    for index in mixedScalarIndexCombinations(for: tensor.shape) {
+        result[index] = tensor[index] * scalar
+    }
+    return result
 }
 
-public func * <T: TensorArithmeticBLAS>(scalar: Complex, tensor: T) -> TensorDenseBLAS<Complex> where T.S == Double {
+public func * <T: TensorArithmeticReference>(scalar: ComplexFloat, tensor: T) -> TensorDenseBLAS<ComplexFloat>
+    where T.S == Float {
     tensor * scalar
 }
 
-public func / <T: TensorArithmeticBLAS>(tensor: T, scalar: Complex) -> TensorDenseBLAS<Complex> where T.S == Double {
-    TensorDenseBLAS<Complex>(shape: tensor.shape, elements: tensor.elements.map { $0 / scalar })
+public func / <T: TensorArithmeticReference>(tensor: T, scalar: ComplexFloat) -> TensorDenseBLAS<ComplexFloat>
+    where T.S == Float {
+    var result = TensorDenseBLAS<ComplexFloat>(shape: tensor.shape, initialValue: .zero)
+    for index in mixedScalarIndexCombinations(for: tensor.shape) {
+        result[index] = tensor[index] / scalar
+    }
+    return result
 }
 
-public func * <T: TensorArithmeticBLAS>(tensor: T, scalar: Double) -> T where T.S == Complex {
-    tensor * Complex(scalar, 0.0)
+public func * <T: TensorArithmeticReference>(tensor: T, scalar: Float) -> T where T.S == ComplexFloat {
+    var result = T(shape: tensor.shape, initialValue: .zero)
+    for index in mixedScalarIndexCombinations(for: tensor.shape) {
+        result[index] = tensor[index] * scalar
+    }
+    return result
 }
 
-public func * <T: TensorArithmeticBLAS>(scalar: Double, tensor: T) -> T where T.S == Complex {
+public func * <T: TensorArithmeticReference>(scalar: Float, tensor: T) -> T where T.S == ComplexFloat {
     tensor * scalar
 }
 
-public func / <T: TensorArithmeticBLAS>(tensor: T, scalar: Double) -> T where T.S == Complex {
-    tensor / Complex(scalar, 0.0)
+public func / <T: TensorArithmeticReference>(tensor: T, scalar: Float) -> T where T.S == ComplexFloat {
+    var result = T(shape: tensor.shape, initialValue: .zero)
+    for index in mixedScalarIndexCombinations(for: tensor.shape) {
+        result[index] = tensor[index] / scalar
+    }
+    return result
+}
+
+public func * <T: TensorArithmeticBLAS>(tensor: T, scalar: ComplexDouble) -> TensorDenseBLAS<ComplexDouble>
+    where T.S == Double {
+    TensorDenseBLAS<ComplexDouble>(shape: tensor.shape, elements: tensor.elements.map { $0 * scalar })
+}
+
+public func * <T: TensorArithmeticBLAS>(scalar: ComplexDouble, tensor: T) -> TensorDenseBLAS<ComplexDouble>
+    where T.S == Double {
+    tensor * scalar
+}
+
+public func / <T: TensorArithmeticBLAS>(tensor: T, scalar: ComplexDouble) -> TensorDenseBLAS<ComplexDouble>
+    where T.S == Double {
+    TensorDenseBLAS<ComplexDouble>(shape: tensor.shape, elements: tensor.elements.map { $0 / scalar })
+}
+
+public func * <T: TensorArithmeticBLAS>(tensor: T, scalar: Double) -> T where T.S == ComplexDouble {
+    tensor * ComplexDouble(scalar, 0.0)
+}
+
+public func * <T: TensorArithmeticBLAS>(scalar: Double, tensor: T) -> T where T.S == ComplexDouble {
+    tensor * scalar
+}
+
+public func / <T: TensorArithmeticBLAS>(tensor: T, scalar: Double) -> T where T.S == ComplexDouble {
+    tensor / ComplexDouble(scalar, 0.0)
+}
+
+public func * <T: TensorArithmeticBLAS>(tensor: T, scalar: ComplexFloat) -> TensorDenseBLAS<ComplexFloat>
+    where T.S == Float {
+    TensorDenseBLAS<ComplexFloat>(shape: tensor.shape, elements: tensor.elements.map { $0 * scalar })
+}
+
+public func * <T: TensorArithmeticBLAS>(scalar: ComplexFloat, tensor: T) -> TensorDenseBLAS<ComplexFloat>
+    where T.S == Float {
+    tensor * scalar
+}
+
+public func / <T: TensorArithmeticBLAS>(tensor: T, scalar: ComplexFloat) -> TensorDenseBLAS<ComplexFloat>
+    where T.S == Float {
+    TensorDenseBLAS<ComplexFloat>(shape: tensor.shape, elements: tensor.elements.map { $0 / scalar })
+}
+
+public func * <T: TensorArithmeticBLAS>(tensor: T, scalar: Float) -> T where T.S == ComplexFloat {
+    tensor * ComplexFloat(scalar, 0.0)
+}
+
+public func * <T: TensorArithmeticBLAS>(scalar: Float, tensor: T) -> T where T.S == ComplexFloat {
+    tensor * scalar
+}
+
+public func / <T: TensorArithmeticBLAS>(tensor: T, scalar: Float) -> T where T.S == ComplexFloat {
+    tensor / ComplexFloat(scalar, 0.0)
 }

--- a/Sources/Tensors/TensorBases.swift
+++ b/Sources/Tensors/TensorBases.swift
@@ -119,9 +119,10 @@ extension MatrixBase: PluMatrix {
 }
 
 extension MatrixBase: MatrixEigen where Implementation: MatrixEigen, Implementation.S == Double {
+    public typealias Eigenvalue = Implementation.Eigenvalue
     public typealias Eigenvectors = MatrixBase<Implementation.Eigenvectors>
 
-    public func eigen() -> Eigen<Eigenvectors> {
+    public func eigen() -> Eigen<Eigenvalue, Eigenvectors> {
         let result = implementation.eigen()
         return Eigen(values: result.values, vectors: MatrixBase<Implementation.Eigenvectors>(result.vectors))
     }

--- a/Sources/Tensors/Vector/VectorDenseBLAS.swift
+++ b/Sources/Tensors/Vector/VectorDenseBLAS.swift
@@ -1,6 +1,7 @@
 #if canImport(Accelerate)
 import AccelerateWrapper
 #endif
+import Numerics
 import OpenBLASWrapper
 
 public struct VectorDenseBLAS<S: PluScalar>: TensorArithmeticBLAS {
@@ -84,6 +85,20 @@ extension VectorDenseBLAS: PluVector {
             return AccelerateOperations.snrm2(Int32(size), values) as! S.Magnitude
             #else
             return OpenBLASOperations.snrm2(Int32(size), values) as! S.Magnitude
+            #endif
+        case is ComplexDouble.Type:
+            var values = BLASComplexStorage.interleaved(elements as! [ComplexDouble])
+            #if canImport(Accelerate)
+            return AccelerateOperations.dznrm2(Int32(size), &values) as! S.Magnitude
+            #else
+            return OpenBLASOperations.dznrm2(Int32(size), &values) as! S.Magnitude
+            #endif
+        case is ComplexFloat.Type:
+            var values = BLASComplexStorage.interleaved(elements as! [ComplexFloat])
+            #if canImport(Accelerate)
+            return AccelerateOperations.scnrm2(Int32(size), &values) as! S.Magnitude
+            #else
+            return OpenBLASOperations.scnrm2(Int32(size), &values) as! S.Magnitude
             #endif
         default:
             return elements.map { $0.magnitude * $0.magnitude }.reduce(.zero, +).squareRoot()

--- a/Sources/Tensors/Vector/VectorDenseReference.swift
+++ b/Sources/Tensors/Vector/VectorDenseReference.swift
@@ -63,4 +63,15 @@ extension VectorDenseReference: VectorArithmeticReference {
 
         self.init(elements)
     }
+
+    public func magnitude() -> S.Magnitude {
+        switch S.self {
+        case is ComplexDouble.Type:
+            return (elements as! [ComplexDouble]).map { $0.mod * $0.mod }.reduce(.zero, +).squareRoot() as! S.Magnitude
+        case is ComplexFloat.Type:
+            return (elements as! [ComplexFloat]).map { $0.mod * $0.mod }.reduce(.zero, +).squareRoot() as! S.Magnitude
+        default:
+            return elements.map { $0.magnitude * $0.magnitude }.reduce(.zero, +).squareRoot()
+        }
+    }
 }

--- a/Tests/LinearSolversTests/DenseLinearSolverTests.swift
+++ b/Tests/LinearSolversTests/DenseLinearSolverTests.swift
@@ -41,10 +41,10 @@ func solveLinearDense_correctness_smallMatrices<MatrixType: PluMatrix>(matrixTyp
 }
 
 @Test func solveLinearDense_complexBLAS() {
-    let A = MatrixDenseBLAS<Complex>([[Complex(1.0, 0.0), Complex(0.0, 1.0)],
-                                      [Complex(2.0, -1.0), Complex(1.0, 1.0)]])
-    let b = VectorDenseReference<Complex>([Complex(2.0, 3.0), Complex(6.0, 2.0)])
-    let expected = VectorDenseReference<Complex>([Complex(1.0, 1.0), Complex(2.0, -1.0)])
+    let A = MatrixDenseBLAS<ComplexDouble>([[ComplexDouble(1.0, 0.0), ComplexDouble(0.0, 1.0)],
+                                      [ComplexDouble(2.0, -1.0), ComplexDouble(1.0, 1.0)]])
+    let b = VectorDenseReference<ComplexDouble>([ComplexDouble(2.0, 3.0), ComplexDouble(6.0, 2.0)])
+    let expected = VectorDenseReference<ComplexDouble>([ComplexDouble(1.0, 1.0), ComplexDouble(2.0, -1.0)])
     let actual = solveLinearDense(A, b)
 
     #expect(actual.isApproximatelyEqual(to: expected, relativeTolerance: 1e-12))

--- a/Tests/TensorsTests/ComplexFloatTests.swift
+++ b/Tests/TensorsTests/ComplexFloatTests.swift
@@ -1,0 +1,103 @@
+import Testing
+@testable import Tensors
+
+@Test func ComplexFloat_plumeriaScalarSupport() {
+    let value = ComplexFloat(1.2345678, -2.3456789)
+
+    #expect(value.round() == ComplexFloat(1.234568, -2.345679))
+    #expect(value.round(precision: 2) == ComplexFloat(1.23, -2.35))
+    #expect(ComplexFloat.i == ComplexFloat(0.0, 1.0))
+    #expect(ComplexFloat(1.0, 2.0).star == ComplexFloat(1.0, -2.0))
+    #expect(ComplexFloat(3.0, 4.0).mod.isApproximatelyEqual(to: 5.0, relativeTolerance: 1e-6))
+    #expect((Float(2.0) + ComplexFloat(1.0, -3.0)) == ComplexFloat(3.0, -3.0))
+}
+
+@Test func ComplexFloat_vectorReferenceAndBLASOperations() {
+    checkComplexFloatVector(VectorDenseReference<ComplexFloat>.self)
+    checkComplexFloatVector(VectorDenseBLAS<ComplexFloat>.self)
+}
+
+@Test func ComplexFloat_matrixReferenceAndBLASOperations() {
+    checkComplexFloatMatrix(MatrixDenseReference<ComplexFloat>.self)
+    checkComplexFloatMatrix(MatrixDenseBLAS<ComplexFloat>.self)
+}
+
+@Test func ComplexFloat_tensorReferenceAndBLASOperations() {
+    checkComplexFloatTensor(TensorDenseReference<ComplexFloat>.self)
+    checkComplexFloatTensor(TensorDenseBLAS<ComplexFloat>.self)
+}
+
+@Test func ComplexFloat_mixedTensorScalarArithmetic() {
+    checkComplexFloatMixedReferenceTensorScalarArithmetic()
+    checkComplexFloatMixedBLASTensorScalarArithmetic()
+}
+
+private func checkComplexFloatVector<V: PluVector>(_ type: V.Type) where V.S == ComplexFloat {
+    let u = V([ComplexFloat(3.0, 4.0), ComplexFloat(0.0, 12.0)])
+    let v = V([ComplexFloat(1.0, -1.0), ComplexFloat(2.0, 0.0)])
+
+    #expect(u.magnitude().isApproximatelyEqual(to: 13.0, relativeTolerance: 1e-6))
+    #expect((u + v).toArray() == [ComplexFloat(4.0, 3.0), ComplexFloat(2.0, 12.0)])
+    #expect((u * ComplexFloat(0.0, 1.0)).toArray() == [ComplexFloat(-4.0, 3.0), ComplexFloat(-12.0, 0.0)])
+    #expect((u / ComplexFloat(2.0, 0.0)).toArray() == [ComplexFloat(1.5, 2.0), ComplexFloat(0.0, 6.0)])
+}
+
+private func checkComplexFloatMatrix<M: PluMatrix>(_ type: M.Type) where M.S == ComplexFloat {
+    let left = M([[ComplexFloat(1.0, 1.0), ComplexFloat(2.0, -1.0)],
+                  [ComplexFloat(0.0, 3.0), ComplexFloat(-1.0, 0.0)]])
+    let right = M([[ComplexFloat(1.0, 0.0), ComplexFloat(0.0, -1.0)],
+                   [ComplexFloat(2.0, 0.0), ComplexFloat(1.0, 1.0)]])
+    let vector = VectorDenseReference<ComplexFloat>([ComplexFloat(1.0, 0.0), ComplexFloat(2.0, 1.0)])
+
+    #expect((left * vector).toArray() == [ComplexFloat(6.0, 1.0), ComplexFloat(-2.0, 2.0)])
+    #expect((left * right).toArray() == [[ComplexFloat(5.0, -1.0), ComplexFloat(4.0, 0.0)],
+                                        [ComplexFloat(-2.0, 3.0), ComplexFloat(2.0, -1.0)]])
+}
+
+private func checkComplexFloatTensor<T: TensorMultiplication & TensorArithmetic>(_ type: T.Type) where T.S == ComplexFloat {
+    let leftValues = nestedComplexFloatArray([[ComplexFloat(1.0, 1.0), ComplexFloat(2.0, 0.0)],
+                                              [ComplexFloat(0.0, 0.0), ComplexFloat(-1.0, 1.0)]])
+    let rightValues = nestedComplexFloatArray([[ComplexFloat(1.0, 0.0), ComplexFloat(0.0, 1.0)],
+                                               [ComplexFloat(2.0, -1.0), ComplexFloat(-1.0, 0.0)]])
+    let left = T(leftValues)
+    let right = T(rightValues)
+    let product = multiply(left, [TensorIndex("i"), TensorIndex("j")], right, [TensorIndex("j"), TensorIndex("k")])
+
+    #expect((left + left)[[0, 0]] == ComplexFloat(2.0, 2.0))
+    #expect((left * ComplexFloat(0.0, 1.0))[[1, 1]] == ComplexFloat(-1.0, -1.0))
+    #expect(product.shape == [2, 2])
+    #expect(product[[0, 0]] == ComplexFloat(5.0, -1.0))
+    #expect(product[[1, 0]] == ComplexFloat(-1.0, 3.0))
+    #expect(product[[0, 1]] == ComplexFloat(-3.0, 1.0))
+    #expect(product[[1, 1]] == ComplexFloat(1.0, -1.0))
+}
+
+private func nestedComplexFloatArray(_ values: [[ComplexFloat]]) -> TensorNestedArray<ComplexFloat> {
+    .array(values.map { .array($0.map { .scalar($0) }) })
+}
+
+private func checkComplexFloatMixedReferenceTensorScalarArithmetic() {
+    let real = TensorDenseReference<Float>(shape: [2], elements: [2.0, -1.0])
+    let complex = TensorDenseReference<ComplexFloat>(shape: [2], elements: [ComplexFloat(2.0, -2.0),
+                                                                             ComplexFloat(0.0, 4.0)])
+
+    #expect((real * ComplexFloat(1.0, -1.0)).elements == [ComplexFloat(2.0, -2.0), ComplexFloat(-1.0, 1.0)])
+    #expect((ComplexFloat(1.0, -1.0) * real).elements == (real * ComplexFloat(1.0, -1.0)).elements)
+    #expect((real / ComplexFloat(1.0, -1.0)).elements == [ComplexFloat(1.0, 1.0), ComplexFloat(-0.5, -0.5)])
+    #expect((complex * Float(2.0)).elements == [ComplexFloat(4.0, -4.0), ComplexFloat(0.0, 8.0)])
+    #expect((Float(2.0) * complex).elements == (complex * Float(2.0)).elements)
+    #expect((complex / Float(2.0)).elements == [ComplexFloat(1.0, -1.0), ComplexFloat(0.0, 2.0)])
+}
+
+private func checkComplexFloatMixedBLASTensorScalarArithmetic() {
+    let real = TensorDenseBLAS<Float>(shape: [2], elements: [2.0, -1.0])
+    let complex = TensorDenseBLAS<ComplexFloat>(shape: [2], elements: [ComplexFloat(2.0, -2.0),
+                                                                       ComplexFloat(0.0, 4.0)])
+
+    #expect((real * ComplexFloat(1.0, -1.0)).elements == [ComplexFloat(2.0, -2.0), ComplexFloat(-1.0, 1.0)])
+    #expect((ComplexFloat(1.0, -1.0) * real).elements == (real * ComplexFloat(1.0, -1.0)).elements)
+    #expect((real / ComplexFloat(1.0, -1.0)).elements == [ComplexFloat(1.0, 1.0), ComplexFloat(-0.5, -0.5)])
+    #expect((complex * Float(2.0)).elements == [ComplexFloat(4.0, -4.0), ComplexFloat(0.0, 8.0)])
+    #expect((Float(2.0) * complex).elements == (complex * Float(2.0)).elements)
+    #expect((complex / Float(2.0)).elements == [ComplexFloat(1.0, -1.0), ComplexFloat(0.0, 2.0)])
+}

--- a/Tests/TensorsTests/MatrixDenseBLASTests.swift
+++ b/Tests/TensorsTests/MatrixDenseBLASTests.swift
@@ -4,10 +4,11 @@ import Testing
 @Test func MatrixDense_BLAS_accelerateComplexVectorMultiplication() {
     #if canImport(Accelerate)
     let A = complexTestMatrixA()
-    let v = VectorDenseReference<Complex>([Complex(1.0, 0.0), Complex(0.0, 1.0), Complex(2.0, 0.0)])
+    let v = VectorDenseReference<ComplexDouble>([ComplexDouble(1.0, 0.0), ComplexDouble(0.0, 1.0),
+                                                 ComplexDouble(2.0, 0.0)])
     let b = A * v
 
-    #expect(b == VectorDenseReference<Complex>([Complex(1.0, 1.0), Complex(6.0, -3.0)]))
+    #expect(b == VectorDenseReference<ComplexDouble>([ComplexDouble(1.0, 1.0), ComplexDouble(6.0, -3.0)]))
 
     var AAccelerate = A
     AAccelerate.blasImplementation = .accelerate
@@ -18,13 +19,13 @@ import Testing
 @Test func MatrixDense_BLAS_accelerateComplexMatrixMultiplication() {
     #if canImport(Accelerate)
     let A = complexTestMatrixA()
-    let B = MatrixDenseBLAS<Complex>([[Complex(1.0, 0.0), Complex(0.0, 1.0)],
-                                      [Complex(2.0, -1.0), Complex(-1.0, 0.0)],
-                                      [Complex(0.0, 0.0), Complex(1.0, 1.0)]])
+    let B = MatrixDenseBLAS<ComplexDouble>([[ComplexDouble(1.0, 0.0), ComplexDouble(0.0, 1.0)],
+                                      [ComplexDouble(2.0, -1.0), ComplexDouble(-1.0, 0.0)],
+                                      [ComplexDouble(0.0, 0.0), ComplexDouble(1.0, 1.0)]])
     let C = A * B
 
-    #expect(C.toArray() == [[Complex(5.0, -1.0), Complex(-2.0, 0.0)],
-                            [Complex(2.0, 3.0), Complex(4.0, 3.0)]])
+    #expect(C.toArray() == [[ComplexDouble(5.0, -1.0), ComplexDouble(-2.0, 0.0)],
+                            [ComplexDouble(2.0, 3.0), ComplexDouble(4.0, 3.0)]])
 
     var AAccelerate = A
     AAccelerate.blasImplementation = .accelerate
@@ -106,7 +107,7 @@ import Testing
     #expect(column.elements == [2.0, 5.0, 8.0])
 }
 
-private func complexTestMatrixA() -> MatrixDenseBLAS<Complex> {
-    MatrixDenseBLAS<Complex>([[Complex(1.0, 1.0), Complex(2.0, 0.0), Complex(0.0, -1.0)],
-                              [Complex(3.0, 0.0), Complex(-1.0, 1.0), Complex(2.0, -1.0)]])
+private func complexTestMatrixA() -> MatrixDenseBLAS<ComplexDouble> {
+    MatrixDenseBLAS<ComplexDouble>([[ComplexDouble(1.0, 1.0), ComplexDouble(2.0, 0.0), ComplexDouble(0.0, -1.0)],
+                              [ComplexDouble(3.0, 0.0), ComplexDouble(-1.0, 1.0), ComplexDouble(2.0, -1.0)]])
 }

--- a/Tests/TensorsTests/MatrixDenseTests.swift
+++ b/Tests/TensorsTests/MatrixDenseTests.swift
@@ -42,8 +42,8 @@ enum MatrixImplementation: CaseIterable, CustomStringConvertible {
 
     func checkComplexVectorMultiplication() {
         switch self {
-        case .reference: verifyComplexVectorMultiplication(MatrixDenseReference<Complex>.self)
-        case .blas: verifyComplexVectorMultiplication(MatrixDenseBLAS<Complex>.self)
+        case .reference: verifyComplexVectorMultiplication(MatrixDenseReference<ComplexDouble>.self)
+        case .blas: verifyComplexVectorMultiplication(MatrixDenseBLAS<ComplexDouble>.self)
         }
     }
 
@@ -56,8 +56,8 @@ enum MatrixImplementation: CaseIterable, CustomStringConvertible {
 
     func checkComplexMatrixMultiplication() {
         switch self {
-        case .reference: verifyComplexMatrixMultiplication(MatrixDenseReference<Complex>.self)
-        case .blas: verifyComplexMatrixMultiplication(MatrixDenseBLAS<Complex>.self)
+        case .reference: verifyComplexMatrixMultiplication(MatrixDenseReference<ComplexDouble>.self)
+        case .blas: verifyComplexMatrixMultiplication(MatrixDenseBLAS<ComplexDouble>.self)
         }
     }
 
@@ -207,10 +207,11 @@ private func verifyVectorMultiplication<M: PluMatrix>(_ type: M.Type) where M.S 
     #expect((matrix * vector).toArray() == [20.0, 47.0])
 }
 
-private func verifyComplexVectorMultiplication<M: PluMatrix>(_ type: M.Type) where M.S == Complex {
+private func verifyComplexVectorMultiplication<M: PluMatrix>(_ type: M.Type) where M.S == ComplexDouble {
     let matrix = complexTestMatrixA(M.self)
-    let vector = VectorDenseReference<Complex>([Complex(1.0, 0.0), Complex(0.0, 1.0), Complex(2.0, 0.0)])
-    #expect(matrix * vector == VectorDenseReference<Complex>([Complex(1.0, 1.0), Complex(6.0, -3.0)]))
+    let vector = VectorDenseReference<ComplexDouble>([ComplexDouble(1.0, 0.0), ComplexDouble(0.0, 1.0),
+                                                      ComplexDouble(2.0, 0.0)])
+    #expect(matrix * vector == VectorDenseReference<ComplexDouble>([ComplexDouble(1.0, 1.0), ComplexDouble(6.0, -3.0)]))
 }
 
 private func verifyMatrixMultiplication<M: PluMatrix>(_ type: M.Type) where M.S == Double {
@@ -219,13 +220,13 @@ private func verifyMatrixMultiplication<M: PluMatrix>(_ type: M.Type) where M.S 
     #expect((left * right).toArray() == [[58.0, 64.0], [139.0, 154.0]])
 }
 
-private func verifyComplexMatrixMultiplication<M: PluMatrix>(_ type: M.Type) where M.S == Complex {
+private func verifyComplexMatrixMultiplication<M: PluMatrix>(_ type: M.Type) where M.S == ComplexDouble {
     let left = complexTestMatrixA(M.self)
-    let right = M([[Complex(1.0, 0.0), Complex(0.0, 1.0)],
-                   [Complex(2.0, -1.0), Complex(-1.0, 0.0)],
-                   [Complex(0.0, 0.0), Complex(1.0, 1.0)]])
-    #expect((left * right).toArray() == [[Complex(5.0, -1.0), Complex(-2.0, 0.0)],
-                                         [Complex(2.0, 3.0), Complex(4.0, 3.0)]])
+    let right = M([[ComplexDouble(1.0, 0.0), ComplexDouble(0.0, 1.0)],
+                   [ComplexDouble(2.0, -1.0), ComplexDouble(-1.0, 0.0)],
+                   [ComplexDouble(0.0, 0.0), ComplexDouble(1.0, 1.0)]])
+    #expect((left * right).toArray() == [[ComplexDouble(5.0, -1.0), ComplexDouble(-2.0, 0.0)],
+                                         [ComplexDouble(2.0, 3.0), ComplexDouble(4.0, 3.0)]])
 }
 
 private func verifyTranspose<M: PluMatrix>(_ type: M.Type) where M.S == Double {
@@ -274,7 +275,7 @@ private func verifyArithmetic<M: PluMatrix>(_ type: M.Type) where M.S == Double 
     #expect((left / 2.0).toArray(round: true) == [[0.6, -1.7], [0.25, 1.0]])
 }
 
-private func complexTestMatrixA<M: PluMatrix>(_ type: M.Type) -> M where M.S == Complex {
-    M([[Complex(1.0, 1.0), Complex(2.0, 0.0), Complex(0.0, -1.0)],
-       [Complex(3.0, 0.0), Complex(-1.0, 1.0), Complex(2.0, -1.0)]])
+private func complexTestMatrixA<M: PluMatrix>(_ type: M.Type) -> M where M.S == ComplexDouble {
+    M([[ComplexDouble(1.0, 1.0), ComplexDouble(2.0, 0.0), ComplexDouble(0.0, -1.0)],
+       [ComplexDouble(3.0, 0.0), ComplexDouble(-1.0, 1.0), ComplexDouble(2.0, -1.0)]])
 }

--- a/Tests/TensorsTests/MatrixOperationsTests.swift
+++ b/Tests/TensorsTests/MatrixOperationsTests.swift
@@ -47,43 +47,45 @@ func Matrix_eigenComplexEigenvalues(implementation: MatrixImplementation) {
     implementation.checkEigenComplexEigenvalues()
 }
 
-private func verifyEigenRealEigenvalues<M: MatrixEigen>(_ type: M.Type) {
+private func verifyEigenRealEigenvalues<M: MatrixEigen>(_ type: M.Type) where M.Eigenvalue == ComplexDouble {
     let matrix = M([[2.0, 0.0],
                     [0.0, 3.0]])
     let eigen = matrix.eigen()
 
-    expectEigenvalues(eigen.values, [Complex(2.0, 0.0), Complex(3.0, 0.0)])
+    expectEigenvalues(eigen.values, [ComplexDouble(2.0, 0.0), ComplexDouble(3.0, 0.0)])
     expectEigenpair(matrix, eigen, column: 0)
     expectEigenpair(matrix, eigen, column: 1)
 }
 
-private func verifyEigenComplexEigenvalues<M: MatrixEigen>(_ type: M.Type) {
+private func verifyEigenComplexEigenvalues<M: MatrixEigen>(_ type: M.Type) where M.Eigenvalue == ComplexDouble {
     let matrix = M([[0.0, -1.0],
                     [1.0, 0.0]])
     let eigen = matrix.eigen()
 
-    expectEigenvalues(eigen.values, [Complex(0.0, 1.0), Complex(0.0, -1.0)])
+    expectEigenvalues(eigen.values, [ComplexDouble(0.0, 1.0), ComplexDouble(0.0, -1.0)])
     expectEigenpair(matrix, eigen, column: 0)
     expectEigenpair(matrix, eigen, column: 1)
 }
 
-private func expectEigenvalues(_ values: [Complex], _ expected: [Complex]) {
+private func expectEigenvalues(_ values: [ComplexDouble], _ expected: [ComplexDouble]) {
     #expect(values.count == expected.count)
     for value in expected {
         #expect(values.contains { $0.isApproximatelyEqual(to: value, relativeTolerance: 1e-12) })
     }
 }
 
-private func expectEigenpair<M: MatrixEigen>(_ matrix: M, _ eigen: Eigen<M.Eigenvectors>, column: Int) {
-    let vector = VectorDenseReference<Complex>((0..<matrix.rows).map { eigen.vectors[$0, column] })
+private func expectEigenpair<M: MatrixEigen>(
+    _ matrix: M, _ eigen: Eigen<M.Eigenvalue, M.Eigenvectors>, column: Int
+) where M.Eigenvalue == ComplexDouble {
+    let vector = VectorDenseReference<ComplexDouble>((0..<matrix.rows).map { eigen.vectors[$0, column] })
     let left = complexMatrix(matrix) * vector
-    let right = VectorDenseReference<Complex>((0..<vector.size).map { eigen.values[column] * vector[$0] })
+    let right = VectorDenseReference<ComplexDouble>((0..<vector.size).map { eigen.values[column] * vector[$0] })
 
     #expect(left.isApproximatelyEqual(to: right, relativeTolerance: 1e-12))
 }
 
-private func complexMatrix<M: MatrixEigen>(_ matrix: M) -> MatrixDenseBLAS<Complex> {
-    MatrixDenseBLAS<Complex>((0..<matrix.rows).map { row in
-        (0..<matrix.columns).map { column in Complex(matrix[row, column], 0.0) }
+private func complexMatrix<M: MatrixEigen>(_ matrix: M) -> MatrixDenseBLAS<ComplexDouble> {
+    MatrixDenseBLAS<ComplexDouble>((0..<matrix.rows).map { row in
+        (0..<matrix.columns).map { column in ComplexDouble(matrix[row, column], 0.0) }
     })
 }

--- a/Tests/TensorsTests/ScalarTests.swift
+++ b/Tests/TensorsTests/ScalarTests.swift
@@ -2,52 +2,52 @@ import Testing
 @testable import Tensors
 
 @Test func Complex_init() {
-    let z = Complex(1.2, 3.4)
+    let z = ComplexDouble(1.2, 3.4)
     #expect(z.real == 1.2)
     #expect(z.imaginary == 3.4)
 }
 
 @Test func Complex_arithmetic() {
-    let a = Complex(1.2, -2.3)
-    let b = Complex(3.4, 5.6)
+    let a = ComplexDouble(1.2, -2.3)
+    let b = ComplexDouble(3.4, 5.6)
 
     #expect(a.real == 1.2)
     #expect(a.imaginary == -2.3)
-    #expect(-a == Complex(-1.2, 2.3))
-    #expect(a+b == Complex(4.6, 3.3))
+    #expect(-a == ComplexDouble(-1.2, 2.3))
+    #expect(a+b == ComplexDouble(4.6, 3.3))
     #expect(a+b == b+a)
-    #expect((a-b).isApproximatelyEqual(to: Complex(-2.2, -7.9)))
-    #expect((a*b).isApproximatelyEqual(to: Complex(16.96, -1.1)))
-    #expect((a/b).isApproximatelyEqual(to: Complex(-0.20503261882572227, -0.3387698042870456)))
+    #expect((a-b).isApproximatelyEqual(to: ComplexDouble(-2.2, -7.9)))
+    #expect((a*b).isApproximatelyEqual(to: ComplexDouble(16.96, -1.1)))
+    #expect((a/b).isApproximatelyEqual(to: ComplexDouble(-0.20503261882572227, -0.3387698042870456)))
 }
 
 @Test func Complex_mixedRealArithmetic() {
-    let z = Complex(3.0, -2.0)
+    let z = ComplexDouble(3.0, -2.0)
 
-    #expect(5.0 + z == Complex(8.0, -2.0))
-    #expect(z + 5.0 == Complex(8.0, -2.0))
-    #expect(5.0 - z == Complex(2.0, 2.0))
-    #expect(z - 5.0 == Complex(-2.0, -2.0))
-    #expect(5.0 * z == Complex(15.0, -10.0))
-    #expect(z * 5.0 == Complex(15.0, -10.0))
-    #expect((5.0 / z).isApproximatelyEqual(to: Complex(15.0/13.0, 10.0/13.0)))
-    #expect((z / 5.0).isApproximatelyEqual(to: Complex(0.6, -0.4)))
+    #expect(5.0 + z == ComplexDouble(8.0, -2.0))
+    #expect(z + 5.0 == ComplexDouble(8.0, -2.0))
+    #expect(5.0 - z == ComplexDouble(2.0, 2.0))
+    #expect(z - 5.0 == ComplexDouble(-2.0, -2.0))
+    #expect(5.0 * z == ComplexDouble(15.0, -10.0))
+    #expect(z * 5.0 == ComplexDouble(15.0, -10.0))
+    #expect((5.0 / z).isApproximatelyEqual(to: ComplexDouble(15.0/13.0, 10.0/13.0)))
+    #expect((z / 5.0).isApproximatelyEqual(to: ComplexDouble(0.6, -0.4)))
 }
 
 @Test func Complex_plumeriaScalarProperties() {
-    let z = Complex(3.0, 4.0)
+    let z = ComplexDouble(3.0, 4.0)
 
-    #expect(Complex.i == Complex(0.0, 1.0))
-    #expect(z.star == Complex(3.0, -4.0))
+    #expect(ComplexDouble.i == ComplexDouble(0.0, 1.0))
+    #expect(z.star == ComplexDouble(3.0, -4.0))
     #expect(z.mod == 5.0)
     #expect(z.arg.isApproximatelyEqual(to: 0.9272952180016122, relativeTolerance: 1e-15))
 }
 
 @Test func Complex_imaginaryUnitSupportsLocalMathNotation() {
-    let i = Complex.i
+    let i = ComplexDouble.i
     let z = 1.2 + 3.4 * i
 
-    #expect(z == Complex(1.2, 3.4))
+    #expect(z == ComplexDouble(1.2, 3.4))
 }
 
 @Test func PluScalar_roundsWithPrecision() {
@@ -55,5 +55,5 @@ import Testing
     #expect(1.23456.round(precision: 2) == 1.23)
     #expect(Float(1.2345678).round() == 1.234568)
     #expect(Float(1.2345678).round(precision: 2) == 1.23)
-    #expect(Complex(1.23456, -2.34567).round(precision: 2) == Complex(1.23, -2.35))
+    #expect(ComplexDouble(1.23456, -2.34567).round(precision: 2) == ComplexDouble(1.23, -2.35))
 }

--- a/Tests/TensorsTests/TensorDenseBLASTests.swift
+++ b/Tests/TensorsTests/TensorDenseBLASTests.swift
@@ -30,23 +30,23 @@ private func tensor(_ values: [[[Double]]]) -> TensorDenseBLAS<Double> {
 @Test func TensorDenseBLAS_mixedScalarArithmetic() {
     let realScalar = TensorDenseBLAS<Double>(shape: [], elements: [2.0])
     let realRank3 = TensorDenseBLAS<Double>(shape: [2, 2, 2], elements: [1.0, 0.0, -1.0, 2.0, 3.0, -2.0, 0.0, 1.0])
-    let complexRank3 = TensorDenseBLAS<Complex>(shape: [2, 2, 2], elements: [
-        Complex(1.0, -1.0), Complex(0.0, 2.0), Complex(-1.0, 0.0), Complex(2.0, 1.0),
-        Complex(3.0, -2.0), Complex(-2.0, 1.0), Complex(0.0, -1.0), Complex(1.0, 0.0)
+    let complexRank3 = TensorDenseBLAS<ComplexDouble>(shape: [2, 2, 2], elements: [
+        ComplexDouble(1.0, -1.0), ComplexDouble(0.0, 2.0), ComplexDouble(-1.0, 0.0), ComplexDouble(2.0, 1.0),
+        ComplexDouble(3.0, -2.0), ComplexDouble(-2.0, 1.0), ComplexDouble(0.0, -1.0), ComplexDouble(1.0, 0.0)
     ])
-    #expect((realScalar * Complex(1.0, -1.0)).elements == [Complex(2.0, -2.0)])
-    #expect((realRank3 * Complex(0.0, 2.0)).elements == [
-        Complex(0.0, 2.0), Complex(0.0, 0.0), Complex(0.0, -2.0), Complex(0.0, 4.0),
-        Complex(0.0, 6.0), Complex(0.0, -4.0), Complex(0.0, 0.0), Complex(0.0, 2.0)
+    #expect((realScalar * ComplexDouble(1.0, -1.0)).elements == [ComplexDouble(2.0, -2.0)])
+    #expect((realRank3 * ComplexDouble(0.0, 2.0)).elements == [
+        ComplexDouble(0.0, 2.0), ComplexDouble(0.0, 0.0), ComplexDouble(0.0, -2.0), ComplexDouble(0.0, 4.0),
+        ComplexDouble(0.0, 6.0), ComplexDouble(0.0, -4.0), ComplexDouble(0.0, 0.0), ComplexDouble(0.0, 2.0)
     ])
-    #expect((Complex(0.0, 2.0) * realRank3).elements == (realRank3 * Complex(0.0, 2.0)).elements)
+    #expect((ComplexDouble(0.0, 2.0) * realRank3).elements == (realRank3 * ComplexDouble(0.0, 2.0)).elements)
     #expect((complexRank3 * 2.0).elements == [
-        Complex(2.0, -2.0), Complex(0.0, 4.0), Complex(-2.0, 0.0), Complex(4.0, 2.0),
-        Complex(6.0, -4.0), Complex(-4.0, 2.0), Complex(0.0, -2.0), Complex(2.0, 0.0)
+        ComplexDouble(2.0, -2.0), ComplexDouble(0.0, 4.0), ComplexDouble(-2.0, 0.0), ComplexDouble(4.0, 2.0),
+        ComplexDouble(6.0, -4.0), ComplexDouble(-4.0, 2.0), ComplexDouble(0.0, -2.0), ComplexDouble(2.0, 0.0)
     ])
     #expect((complexRank3 / 2.0).elements == [
-        Complex(0.5, -0.5), Complex(0.0, 1.0), Complex(-0.5, 0.0), Complex(1.0, 0.5),
-        Complex(1.5, -1.0), Complex(-1.0, 0.5), Complex(0.0, -0.5), Complex(0.5, 0.0)
+        ComplexDouble(0.5, -0.5), ComplexDouble(0.0, 1.0), ComplexDouble(-0.5, 0.0), ComplexDouble(1.0, 0.5),
+        ComplexDouble(1.5, -1.0), ComplexDouble(-1.0, 0.5), ComplexDouble(0.0, -0.5), ComplexDouble(0.5, 0.0)
     ])
 }
 

--- a/Tests/TensorsTests/VectorTests.swift
+++ b/Tests/TensorsTests/VectorTests.swift
@@ -24,8 +24,8 @@ enum VectorImplementation: CaseIterable, CustomStringConvertible {
 
     func checkComplexInit() {
         switch self {
-        case .reference: verifyComplexInit(VectorDenseReference<Complex>.self)
-        case .blas: verifyComplexInit(VectorDenseBLAS<Complex>.self)
+        case .reference: verifyComplexInit(VectorDenseReference<ComplexDouble>.self)
+        case .blas: verifyComplexInit(VectorDenseBLAS<ComplexDouble>.self)
         }
     }
 
@@ -52,8 +52,8 @@ enum VectorImplementation: CaseIterable, CustomStringConvertible {
 
     func checkComplexArithmetic() {
         switch self {
-        case .reference: verifyComplexArithmetic(VectorDenseReference<Complex>.self)
-        case .blas: verifyComplexArithmetic(VectorDenseBLAS<Complex>.self)
+        case .reference: verifyComplexArithmetic(VectorDenseReference<ComplexDouble>.self)
+        case .blas: verifyComplexArithmetic(VectorDenseBLAS<ComplexDouble>.self)
         }
     }
 
@@ -112,17 +112,17 @@ private func verifyDoubleInit<V: PluVector>(_ type: V.Type) where V.S == Double 
     #expect(v[1] == a[1])
 }
 
-private func verifyComplexInit<V: PluVector>(_ type: V.Type) where V.S == Complex {
-    let s = Complex(a[0], a[1])
-    let t = Complex(b[0], b[1])
+private func verifyComplexInit<V: PluVector>(_ type: V.Type) where V.S == ComplexDouble {
+    let s = ComplexDouble(a[0], a[1])
+    let t = ComplexDouble(b[0], b[1])
     let v = V([s, t])
     #expect(v.size == a.count)
     #expect(v[0].real == a[0])
     #expect(v[0].imaginary == a[1])
-    #expect(v[0] == Complex(a[0], a[1]))
+    #expect(v[0] == ComplexDouble(a[0], a[1]))
     #expect(v[1].real == b[0])
     #expect(v[1].imaginary == b[1])
-    #expect(v[1] == Complex(b[0], b[1]))
+    #expect(v[1] == ComplexDouble(b[0], b[1]))
 }
 
 private func verifyNestedArrayInitializer<V: PluVector>(_ type: V.Type) where V.S == Double {
@@ -152,13 +152,13 @@ private func verifyArithmetic<V: PluVector>(_ type: V.Type) where V.S == Double 
     #expect((u / 2.0).toArray(round: true) == [0.6, -1.7])
 }
 
-private func verifyComplexArithmetic<V: PluVector>(_ type: V.Type) where V.S == Complex {
-    let u = V([Complex(1.0, -1.0), Complex(0.0, 2.0)])
-    let v = V([Complex(2.0, 1.0), Complex(-3.0, 0.0)])
+private func verifyComplexArithmetic<V: PluVector>(_ type: V.Type) where V.S == ComplexDouble {
+    let u = V([ComplexDouble(1.0, -1.0), ComplexDouble(0.0, 2.0)])
+    let v = V([ComplexDouble(2.0, 1.0), ComplexDouble(-3.0, 0.0)])
 
-    #expect((u + v).toArray() == [Complex(3.0, 0.0), Complex(-3.0, 2.0)])
-    #expect((u * Complex(0.0, 2.0)).toArray() == [Complex(2.0, 2.0), Complex(-4.0, 0.0)])
-    #expect((u * Complex(2.0, 0.0)).toArray() == [Complex(2.0, -2.0), Complex(0.0, 4.0)])
+    #expect((u + v).toArray() == [ComplexDouble(3.0, 0.0), ComplexDouble(-3.0, 2.0)])
+    #expect((u * ComplexDouble(0.0, 2.0)).toArray() == [ComplexDouble(2.0, 2.0), ComplexDouble(-4.0, 0.0)])
+    #expect((u * ComplexDouble(2.0, 0.0)).toArray() == [ComplexDouble(2.0, -2.0), ComplexDouble(0.0, 4.0)])
 }
 
 private func verifyToArray<V: PluVector>(_ type: V.Type) where V.S == Double {


### PR DESCRIPTION
## Changes

- Closes #46.
- Added Complex<Float> scalar support alongside Complex<Double>.
- Added Complex<Float> BLAS wrappers and BLAS-backed vector, matrix, and tensor arithmetic coverage.
- Made Eigen generic over eigenvalue scalar type.
- Added Complex<Float> mixed real-scalar arithmetic and benchmark coverage.
- Added tests for Complex<Float> scalar, vector, matrix, tensor, and mixed scalar behavior.