### PR TITLE
Use LAPACK for BLAS determinant and inverse

### DIFF
--- a/Sources/AccelerateWrapper/AccelerateOperations.swift
+++ b/Sources/AccelerateWrapper/AccelerateOperations.swift
@@ -304,6 +304,134 @@ public struct AccelerateOperations {
         }
     }
 
+    public static func sgetrf(_ n: Int32, _ a: inout [Float]) -> (pivots: [Int32], info: Int32) {
+        var nMutable = n
+        var lda = n
+        var pivots = Array<Int32>(repeating: 0, count: Int(n))
+        var info = Int32(0)
+        Accelerate.sgetrf_(&nMutable, &nMutable, &a, &lda, &pivots, &info)
+        return (pivots, info)
+    }
+
+    public static func dgetrf(_ n: Int32, _ a: inout [Double]) -> (pivots: [Int32], info: Int32) {
+        var nMutable = n
+        var lda = n
+        var pivots = Array<Int32>(repeating: 0, count: Int(n))
+        var info = Int32(0)
+        Accelerate.dgetrf_(&nMutable, &nMutable, &a, &lda, &pivots, &info)
+        return (pivots, info)
+    }
+
+    public static func cgetrf(_ n: Int32, _ a: inout [Float]) -> (pivots: [Int32], info: Int32) {
+        var nMutable = n
+        var lda = n
+        var pivots = Array<Int32>(repeating: 0, count: Int(n))
+        var info = Int32(0)
+        a.withUnsafeMutableBufferPointer { a in
+            Accelerate.cgetrf_(
+                &nMutable, &nMutable, OpaquePointer(UnsafeMutableRawPointer(a.baseAddress!)), &lda, &pivots, &info
+            )
+        }
+        return (pivots, info)
+    }
+
+    public static func zgetrf(_ n: Int32, _ a: inout [Double]) -> (pivots: [Int32], info: Int32) {
+        var nMutable = n
+        var lda = n
+        var pivots = Array<Int32>(repeating: 0, count: Int(n))
+        var info = Int32(0)
+        a.withUnsafeMutableBufferPointer { a in
+            Accelerate.zgetrf_(
+                &nMutable, &nMutable, OpaquePointer(UnsafeMutableRawPointer(a.baseAddress!)), &lda, &pivots, &info
+            )
+        }
+        return (pivots, info)
+    }
+
+    public static func sgetri(_ n: Int32, _ a: inout [Float], _ pivots: [Int32]) -> Int32 {
+        var nMutable = n
+        var lda = n
+        var pivots = pivots
+        var workQuery = Float.zero
+        var lwork = Int32(-1)
+        var info = Int32(0)
+        Accelerate.sgetri_(&nMutable, &a, &lda, &pivots, &workQuery, &lwork, &info)
+        lwork = Int32(workQuery)
+        var work = Array(repeating: Float.zero, count: Int(lwork))
+        Accelerate.sgetri_(&nMutable, &a, &lda, &pivots, &work, &lwork, &info)
+        return info
+    }
+
+    public static func dgetri(_ n: Int32, _ a: inout [Double], _ pivots: [Int32]) -> Int32 {
+        var nMutable = n
+        var lda = n
+        var pivots = pivots
+        var workQuery = Double.zero
+        var lwork = Int32(-1)
+        var info = Int32(0)
+        Accelerate.dgetri_(&nMutable, &a, &lda, &pivots, &workQuery, &lwork, &info)
+        lwork = Int32(workQuery)
+        var work = Array(repeating: Double.zero, count: Int(lwork))
+        Accelerate.dgetri_(&nMutable, &a, &lda, &pivots, &work, &lwork, &info)
+        return info
+    }
+
+    public static func cgetri(_ n: Int32, _ a: inout [Float], _ pivots: [Int32]) -> Int32 {
+        var nMutable = n
+        var lda = n
+        var pivots = pivots
+        var workQuery = [Float.zero, Float.zero]
+        var lwork = Int32(-1)
+        var info = Int32(0)
+        a.withUnsafeMutableBufferPointer { a in
+            workQuery.withUnsafeMutableBufferPointer { work in
+                Accelerate.cgetri_(
+                    &nMutable, OpaquePointer(UnsafeMutableRawPointer(a.baseAddress!)), &lda, &pivots,
+                    OpaquePointer(UnsafeMutableRawPointer(work.baseAddress!)), &lwork, &info
+                )
+            }
+        }
+        lwork = Int32(workQuery[0])
+        var work = Array(repeating: Float.zero, count: Int(lwork) * 2)
+        a.withUnsafeMutableBufferPointer { a in
+            work.withUnsafeMutableBufferPointer { work in
+                Accelerate.cgetri_(
+                    &nMutable, OpaquePointer(UnsafeMutableRawPointer(a.baseAddress!)), &lda, &pivots,
+                    OpaquePointer(UnsafeMutableRawPointer(work.baseAddress!)), &lwork, &info
+                )
+            }
+        }
+        return info
+    }
+
+    public static func zgetri(_ n: Int32, _ a: inout [Double], _ pivots: [Int32]) -> Int32 {
+        var nMutable = n
+        var lda = n
+        var pivots = pivots
+        var workQuery = [Double.zero, Double.zero]
+        var lwork = Int32(-1)
+        var info = Int32(0)
+        a.withUnsafeMutableBufferPointer { a in
+            workQuery.withUnsafeMutableBufferPointer { work in
+                Accelerate.zgetri_(
+                    &nMutable, OpaquePointer(UnsafeMutableRawPointer(a.baseAddress!)), &lda, &pivots,
+                    OpaquePointer(UnsafeMutableRawPointer(work.baseAddress!)), &lwork, &info
+                )
+            }
+        }
+        lwork = Int32(workQuery[0])
+        var work = Array(repeating: Double.zero, count: Int(lwork) * 2)
+        a.withUnsafeMutableBufferPointer { a in
+            work.withUnsafeMutableBufferPointer { work in
+                Accelerate.zgetri_(
+                    &nMutable, OpaquePointer(UnsafeMutableRawPointer(a.baseAddress!)), &lda, &pivots,
+                    OpaquePointer(UnsafeMutableRawPointer(work.baseAddress!)), &lwork, &info
+                )
+            }
+        }
+        return info
+    }
+
     public static func dgesv(_ n: Int32, _ a: UnsafeMutablePointer<Double>, _ b: UnsafeMutablePointer<Double>)
         -> Int32 {
         var nMutable = n

--- a/Sources/OpenBLASWrapper/OpenBLASOperations.swift
+++ b/Sources/OpenBLASWrapper/OpenBLASOperations.swift
@@ -273,6 +273,134 @@ public enum OpenBLASOperations {
         }
     }
 
+    public static func sgetrf(_ n: Int32, _ a: inout [Float]) -> (pivots: [Int32], info: Int32) {
+        var nMutable = n
+        var lda = n
+        var pivots = Array<Int32>(repeating: 0, count: Int(n))
+        var info = Int32(0)
+        COpenBLAS.sgetrf_(&nMutable, &nMutable, &a, &lda, &pivots, &info)
+        return (pivots, info)
+    }
+
+    public static func dgetrf(_ n: Int32, _ a: inout [Double]) -> (pivots: [Int32], info: Int32) {
+        var nMutable = n
+        var lda = n
+        var pivots = Array<Int32>(repeating: 0, count: Int(n))
+        var info = Int32(0)
+        COpenBLAS.dgetrf_(&nMutable, &nMutable, &a, &lda, &pivots, &info)
+        return (pivots, info)
+    }
+
+    public static func cgetrf(_ n: Int32, _ a: inout [Float]) -> (pivots: [Int32], info: Int32) {
+        var nMutable = n
+        var lda = n
+        var pivots = Array<Int32>(repeating: 0, count: Int(n))
+        var info = Int32(0)
+        _ = a.withUnsafeMutableBufferPointer { a in
+            COpenBLAS.cgetrf_(
+                &nMutable, &nMutable, OpaquePointer(UnsafeMutableRawPointer(a.baseAddress!)), &lda, &pivots, &info
+            )
+        }
+        return (pivots, info)
+    }
+
+    public static func zgetrf(_ n: Int32, _ a: inout [Double]) -> (pivots: [Int32], info: Int32) {
+        var nMutable = n
+        var lda = n
+        var pivots = Array<Int32>(repeating: 0, count: Int(n))
+        var info = Int32(0)
+        _ = a.withUnsafeMutableBufferPointer { a in
+            COpenBLAS.zgetrf_(
+                &nMutable, &nMutable, OpaquePointer(UnsafeMutableRawPointer(a.baseAddress!)), &lda, &pivots, &info
+            )
+        }
+        return (pivots, info)
+    }
+
+    public static func sgetri(_ n: Int32, _ a: inout [Float], _ pivots: [Int32]) -> Int32 {
+        var nMutable = n
+        var lda = n
+        var pivots = pivots
+        var workQuery = Float.zero
+        var lwork = Int32(-1)
+        var info = Int32(0)
+        COpenBLAS.sgetri_(&nMutable, &a, &lda, &pivots, &workQuery, &lwork, &info)
+        lwork = Int32(workQuery)
+        var work = Array(repeating: Float.zero, count: Int(lwork))
+        COpenBLAS.sgetri_(&nMutable, &a, &lda, &pivots, &work, &lwork, &info)
+        return info
+    }
+
+    public static func dgetri(_ n: Int32, _ a: inout [Double], _ pivots: [Int32]) -> Int32 {
+        var nMutable = n
+        var lda = n
+        var pivots = pivots
+        var workQuery = Double.zero
+        var lwork = Int32(-1)
+        var info = Int32(0)
+        COpenBLAS.dgetri_(&nMutable, &a, &lda, &pivots, &workQuery, &lwork, &info)
+        lwork = Int32(workQuery)
+        var work = Array(repeating: Double.zero, count: Int(lwork))
+        COpenBLAS.dgetri_(&nMutable, &a, &lda, &pivots, &work, &lwork, &info)
+        return info
+    }
+
+    public static func cgetri(_ n: Int32, _ a: inout [Float], _ pivots: [Int32]) -> Int32 {
+        var nMutable = n
+        var lda = n
+        var pivots = pivots
+        var workQuery = [Float.zero, Float.zero]
+        var lwork = Int32(-1)
+        var info = Int32(0)
+        a.withUnsafeMutableBufferPointer { a in
+            workQuery.withUnsafeMutableBufferPointer { work in
+                COpenBLAS.cgetri_(
+                    &nMutable, OpaquePointer(UnsafeMutableRawPointer(a.baseAddress!)), &lda, &pivots,
+                    OpaquePointer(UnsafeMutableRawPointer(work.baseAddress!)), &lwork, &info
+                )
+            }
+        }
+        lwork = Int32(workQuery[0])
+        var work = Array(repeating: Float.zero, count: Int(lwork) * 2)
+        a.withUnsafeMutableBufferPointer { a in
+            work.withUnsafeMutableBufferPointer { work in
+                COpenBLAS.cgetri_(
+                    &nMutable, OpaquePointer(UnsafeMutableRawPointer(a.baseAddress!)), &lda, &pivots,
+                    OpaquePointer(UnsafeMutableRawPointer(work.baseAddress!)), &lwork, &info
+                )
+            }
+        }
+        return info
+    }
+
+    public static func zgetri(_ n: Int32, _ a: inout [Double], _ pivots: [Int32]) -> Int32 {
+        var nMutable = n
+        var lda = n
+        var pivots = pivots
+        var workQuery = [Double.zero, Double.zero]
+        var lwork = Int32(-1)
+        var info = Int32(0)
+        a.withUnsafeMutableBufferPointer { a in
+            workQuery.withUnsafeMutableBufferPointer { work in
+                COpenBLAS.zgetri_(
+                    &nMutable, OpaquePointer(UnsafeMutableRawPointer(a.baseAddress!)), &lda, &pivots,
+                    OpaquePointer(UnsafeMutableRawPointer(work.baseAddress!)), &lwork, &info
+                )
+            }
+        }
+        lwork = Int32(workQuery[0])
+        var work = Array(repeating: Double.zero, count: Int(lwork) * 2)
+        a.withUnsafeMutableBufferPointer { a in
+            work.withUnsafeMutableBufferPointer { work in
+                COpenBLAS.zgetri_(
+                    &nMutable, OpaquePointer(UnsafeMutableRawPointer(a.baseAddress!)), &lda, &pivots,
+                    OpaquePointer(UnsafeMutableRawPointer(work.baseAddress!)), &lwork, &info
+                )
+            }
+        }
+        return info
+    }
+
     public static func dgesv(_ n: Int32, _ a: UnsafeMutablePointer<Double>, _ b: UnsafeMutablePointer<Double>)
         -> Int32 {
         var nMutable = n

--- a/Sources/PlumeriaBenchmarks/main.swift
+++ b/Sources/PlumeriaBenchmarks/main.swift
@@ -79,9 +79,10 @@ func printFloatBenchmark(_ operation: String, _ size: String, double: TimedResul
 
 func printComplexFloatBenchmark(_ operation: String, _ size: String, complex: TimedResult, complexFloat: TimedResult) {
     print("  \(operation) \(size)")
-    print("    Complex:  median \(format(complex.median)) ms, best \(format(complex.best)) ms")
-    print("    ComplexF: median \(format(complexFloat.median)) ms, best \(format(complexFloat.best)) ms")
-    print("    ratio:    \(ratio(left: complex.median, "Complex", right: complexFloat.median, "ComplexF"))")
+    print("    ComplexDouble: median \(format(complex.median)) ms, best \(format(complex.best)) ms")
+    print("    ComplexFloat:  median \(format(complexFloat.median)) ms, best \(format(complexFloat.best)) ms")
+    let speedRatio = ratio(left: complex.median, "ComplexDouble", right: complexFloat.median, "ComplexFloat")
+    print("    ratio:         \(speedRatio)")
     print("")
 }
 
@@ -160,6 +161,15 @@ func matrixRows(rows: Int, columns: Int) -> [[Double]] {
         values.append(rowValues)
     }
     return values
+}
+
+func invertibleMatrixRows(size: Int) -> [[Double]] {
+    (0..<size).map { row in
+        (0..<size).map { column in
+            let value = Double(((row * 31 + column * 17) % 101) - 50) / 11.0
+            return row == column ? value + Double(size) : value
+        }
+    }
 }
 
 func matrixFloatRows(rows: Int, columns: Int) -> [[Float]] {
@@ -258,6 +268,7 @@ func benchmarkMatrices() -> Double {
     let largeMVRows = matrixRows(rows: 1_536, columns: 1_536)
     let mmLeftRows = matrixRows(rows: 128, columns: 128)
     let mmRightRows = matrixRows(rows: 128, columns: 128)
+    let detRows = invertibleMatrixRows(size: 96)
     let referenceAdd = MatrixDenseReference(addRows)
     let blasAdd = MatrixDenseBLAS(addRows)
     let referenceLargeAdd = MatrixDenseReference(largeAddRows)
@@ -270,6 +281,8 @@ func benchmarkMatrices() -> Double {
     let referenceMMRight = MatrixDenseReference(mmRightRows)
     let blasMMLeft = MatrixDenseBLAS(mmLeftRows)
     let blasMMRight = MatrixDenseBLAS(mmRightRows)
+    let referenceDet = MatrixDenseReference(detRows)
+    let blasDet = MatrixDenseBLAS(detRows)
     var checksum = 0.0
     checksum += compareBenchmark("add", "256x256", iterations: 5, reference: {
         let result = referenceAdd + referenceAdd
@@ -304,6 +317,18 @@ func benchmarkMatrices() -> Double {
         return result[0, 0] + result[result.rows - 1, result.columns - 1]
     }, blas: {
         let result = blasMMLeft * blasMMRight
+        return result[0, 0] + result[result.rows - 1, result.columns - 1]
+    })
+    checksum += compareBenchmark("determinant", "96x96", samples: 3, reference: {
+        referenceDet.det
+    }, blas: {
+        blasDet.det
+    })
+    checksum += compareBenchmark("inverse", "96x96", samples: 3, reference: {
+        let result = referenceDet.inverse()
+        return result[0, 0] + result[result.rows - 1, result.columns - 1]
+    }, blas: {
+        let result = blasDet.inverse()
         return result[0, 0] + result[result.rows - 1, result.columns - 1]
     })
     return checksum
@@ -420,7 +445,7 @@ func benchmarkFloatScalars() -> Double {
 }
 
 func benchmarkComplexFloatScalars() -> Double {
-    print("ComplexF vs Complex")
+    print("ComplexFloat vs ComplexDouble")
     let complexVector = VectorDenseBLAS(vectorComplexValues(count: 100_000))
     let complexFloatVector = VectorDenseBLAS(vectorComplexFloatValues(count: 100_000))
     let complexMatrixVector = VectorDenseBLAS(vectorComplexValues(count: 384))

--- a/Sources/Tensors/Matrix/MatrixDenseBLAS.swift
+++ b/Sources/Tensors/Matrix/MatrixDenseBLAS.swift
@@ -2,9 +2,7 @@ import AccelerateWrapper
 import Numerics
 import OpenBLASWrapper
 
-// Usage of MatrixArithmeticReference is temporary until determinant and inverse use LAPACK.
-public struct MatrixDenseBLAS<S: PluScalar>: MatrixArithmeticReference, TensorArithmeticBLAS,
-                                             MatrixColumnMajorInitializable, Equatable {
+public struct MatrixDenseBLAS<S: PluScalar>: TensorArithmeticBLAS, MatrixColumnMajorInitializable, Equatable {
     private var view: TensorFlatView<S>
     public var blasImplementation: BLAS
 
@@ -286,6 +284,28 @@ extension MatrixDenseBLAS {
 }
 
 extension MatrixDenseBLAS {
+    public var det: S {
+        precondition(rows == columns, "Determinant requires a square matrix")
+        switch S.self {
+        case is Double.Type: return doubleDeterminant() as! S
+        case is Float.Type: return floatDeterminant() as! S
+        case is ComplexDouble.Type: return complexDoubleDeterminant() as! S
+        case is ComplexFloat.Type: return complexFloatDeterminant() as! S
+        default: fatalError("Unsupported scalar type")
+        }
+    }
+
+    public func inverse() -> MatrixDenseBLAS<S> {
+        precondition(rows == columns, "Inverse requires a square matrix")
+        switch S.self {
+        case is Double.Type: return doubleInverse() as! MatrixDenseBLAS<S>
+        case is Float.Type: return floatInverse() as! MatrixDenseBLAS<S>
+        case is ComplexDouble.Type: return complexDoubleInverse() as! MatrixDenseBLAS<S>
+        case is ComplexFloat.Type: return complexFloatInverse() as! MatrixDenseBLAS<S>
+        default: fatalError("Unsupported scalar type")
+        }
+    }
+
     public func transpose() -> MatrixDenseBLAS<S> {
         var transposed = MatrixDenseBLAS(rows: columns, columns: rows)
         for row in 0..<rows {
@@ -332,6 +352,174 @@ extension MatrixDenseBLAS {
         return matrix.flatten(columnMajorOrder: true)
     }
 
+    private func doubleFactorization() -> (matrix: [Double], pivots: [Int32], info: Int32) {
+        var matrix = columnMajorStorage() as! [Double]
+        let factorization = doubleGetrf(Int32(rows), &matrix)
+        return (matrix, factorization.pivots, factorization.info)
+    }
+
+    private func floatFactorization() -> (matrix: [Float], pivots: [Int32], info: Int32) {
+        var matrix = columnMajorStorage() as! [Float]
+        let factorization = floatGetrf(Int32(rows), &matrix)
+        return (matrix, factorization.pivots, factorization.info)
+    }
+
+    private func complexDoubleFactorization() -> (matrix: [Double], pivots: [Int32], info: Int32) {
+        var matrix = BLASComplexStorage.interleaved(columnMajorStorage() as! [ComplexDouble])
+        let factorization = complexDoubleGetrf(Int32(rows), &matrix)
+        return (matrix, factorization.pivots, factorization.info)
+    }
+
+    private func complexFloatFactorization() -> (matrix: [Float], pivots: [Int32], info: Int32) {
+        var matrix = BLASComplexStorage.interleaved(columnMajorStorage() as! [ComplexFloat])
+        let factorization = complexFloatGetrf(Int32(rows), &matrix)
+        return (matrix, factorization.pivots, factorization.info)
+    }
+
+    private func doubleDeterminant() -> Double {
+        let factorization = doubleFactorization()
+        precondition(factorization.info >= 0, "LAPACK determinant failed with info \(factorization.info)")
+        if factorization.info > 0 { return .zero }
+        return luDeterminant(from: factorization.matrix, pivots: factorization.pivots, one: 1.0)
+    }
+
+    private func floatDeterminant() -> Float {
+        let factorization = floatFactorization()
+        precondition(factorization.info >= 0, "LAPACK determinant failed with info \(factorization.info)")
+        if factorization.info > 0 { return .zero }
+        return luDeterminant(from: factorization.matrix, pivots: factorization.pivots, one: Float(1.0))
+    }
+
+    private func complexDoubleDeterminant() -> ComplexDouble {
+        let factorization = complexDoubleFactorization()
+        precondition(factorization.info >= 0, "LAPACK determinant failed with info \(factorization.info)")
+        if factorization.info > 0 { return .zero }
+        let matrix = BLASComplexStorage.complexValues(factorization.matrix) as [ComplexDouble]
+        return luDeterminant(from: matrix, pivots: factorization.pivots, one: ComplexDouble(1.0, 0.0))
+    }
+
+    private func complexFloatDeterminant() -> ComplexFloat {
+        let factorization = complexFloatFactorization()
+        precondition(factorization.info >= 0, "LAPACK determinant failed with info \(factorization.info)")
+        if factorization.info > 0 { return .zero }
+        let matrix = BLASComplexStorage.complexValues(factorization.matrix) as [ComplexFloat]
+        return luDeterminant(from: matrix, pivots: factorization.pivots, one: ComplexFloat(1.0, 0.0))
+    }
+
+    private func luDeterminant<T: PluScalar>(from matrix: [T], pivots: [Int32], one: T) -> T {
+        var result = one
+        for index in 0..<rows {
+            if pivots[index] != Int32(index + 1) { result = -result }
+            result *= matrix[index + rows * index]
+        }
+        return result
+    }
+
+    private func doubleInverse() -> MatrixDenseBLAS<Double> {
+        var factorization = doubleFactorization()
+        precondition(factorization.info == 0, "Matrix must be invertible")
+        let info = doubleGetri(Int32(rows), &factorization.matrix, factorization.pivots)
+        precondition(info == 0, "LAPACK inverse failed with info \(info)")
+        return MatrixDenseBLAS<Double>(rows: rows, columns: columns, values: factorization.matrix)
+    }
+
+    private func floatInverse() -> MatrixDenseBLAS<Float> {
+        var factorization = floatFactorization()
+        precondition(factorization.info == 0, "Matrix must be invertible")
+        let info = floatGetri(Int32(rows), &factorization.matrix, factorization.pivots)
+        precondition(info == 0, "LAPACK inverse failed with info \(info)")
+        return MatrixDenseBLAS<Float>(rows: rows, columns: columns, values: factorization.matrix)
+    }
+
+    private func complexDoubleInverse() -> MatrixDenseBLAS<ComplexDouble> {
+        var factorization = complexDoubleFactorization()
+        precondition(factorization.info == 0, "Matrix must be invertible")
+        let info = complexDoubleGetri(Int32(rows), &factorization.matrix, factorization.pivots)
+        precondition(info == 0, "LAPACK inverse failed with info \(info)")
+        return MatrixDenseBLAS<ComplexDouble>(rows: rows, columns: columns,
+                                              values: BLASComplexStorage.complexValues(factorization.matrix))
+    }
+
+    private func complexFloatInverse() -> MatrixDenseBLAS<ComplexFloat> {
+        var factorization = complexFloatFactorization()
+        precondition(factorization.info == 0, "Matrix must be invertible")
+        let info = complexFloatGetri(Int32(rows), &factorization.matrix, factorization.pivots)
+        precondition(info == 0, "LAPACK inverse failed with info \(info)")
+        return MatrixDenseBLAS<ComplexFloat>(rows: rows, columns: columns,
+                                             values: BLASComplexStorage.complexValues(factorization.matrix))
+    }
+
+    private func doubleGetrf(_ n: Int32, _ matrix: inout [Double]) -> (pivots: [Int32], info: Int32) {
+        switch blasImplementation {
+        #if canImport(Accelerate)
+        case .accelerate: return AccelerateOperations.dgetrf(n, &matrix)
+        #endif
+        case .openBLAS: return OpenBLASOperations.dgetrf(n, &matrix)
+        }
+    }
+
+    private func floatGetrf(_ n: Int32, _ matrix: inout [Float]) -> (pivots: [Int32], info: Int32) {
+        switch blasImplementation {
+        #if canImport(Accelerate)
+        case .accelerate: return AccelerateOperations.sgetrf(n, &matrix)
+        #endif
+        case .openBLAS: return OpenBLASOperations.sgetrf(n, &matrix)
+        }
+    }
+
+    private func complexDoubleGetrf(_ n: Int32, _ matrix: inout [Double]) -> (pivots: [Int32], info: Int32) {
+        switch blasImplementation {
+        #if canImport(Accelerate)
+        case .accelerate: return AccelerateOperations.zgetrf(n, &matrix)
+        #endif
+        case .openBLAS: return OpenBLASOperations.zgetrf(n, &matrix)
+        }
+    }
+
+    private func complexFloatGetrf(_ n: Int32, _ matrix: inout [Float]) -> (pivots: [Int32], info: Int32) {
+        switch blasImplementation {
+        #if canImport(Accelerate)
+        case .accelerate: return AccelerateOperations.cgetrf(n, &matrix)
+        #endif
+        case .openBLAS: return OpenBLASOperations.cgetrf(n, &matrix)
+        }
+    }
+
+    private func doubleGetri(_ n: Int32, _ matrix: inout [Double], _ pivots: [Int32]) -> Int32 {
+        switch blasImplementation {
+        #if canImport(Accelerate)
+        case .accelerate: return AccelerateOperations.dgetri(n, &matrix, pivots)
+        #endif
+        case .openBLAS: return OpenBLASOperations.dgetri(n, &matrix, pivots)
+        }
+    }
+
+    private func floatGetri(_ n: Int32, _ matrix: inout [Float], _ pivots: [Int32]) -> Int32 {
+        switch blasImplementation {
+        #if canImport(Accelerate)
+        case .accelerate: return AccelerateOperations.sgetri(n, &matrix, pivots)
+        #endif
+        case .openBLAS: return OpenBLASOperations.sgetri(n, &matrix, pivots)
+        }
+    }
+
+    private func complexDoubleGetri(_ n: Int32, _ matrix: inout [Double], _ pivots: [Int32]) -> Int32 {
+        switch blasImplementation {
+        #if canImport(Accelerate)
+        case .accelerate: return AccelerateOperations.zgetri(n, &matrix, pivots)
+        #endif
+        case .openBLAS: return OpenBLASOperations.zgetri(n, &matrix, pivots)
+        }
+    }
+
+    private func complexFloatGetri(_ n: Int32, _ matrix: inout [Float], _ pivots: [Int32]) -> Int32 {
+        switch blasImplementation {
+        #if canImport(Accelerate)
+        case .accelerate: return AccelerateOperations.cgetri(n, &matrix, pivots)
+        #endif
+        case .openBLAS: return OpenBLASOperations.cgetri(n, &matrix, pivots)
+        }
+    }
 }
 
 extension MatrixDenseBLAS: MatrixEigen where S == Double {

--- a/Tests/TensorsTests/MatrixOperationsTests.swift
+++ b/Tests/TensorsTests/MatrixOperationsTests.swift
@@ -17,9 +17,61 @@ import Testing
     let identity = MatrixDenseBLAS<Double>.identity(size: 2)
 
     #expect(identity.toArray() == [[1.0, 0.0], [0.0, 1.0]])
-    #expect(inverse.toArray() == [[-2.0, 1.0], [1.5, -0.5]])
-    #expect((matrix * inverse).isApproximatelyEqual(to: identity, relativeTolerance: 1e-12))
+    expectApproximatelyEqual(inverse, [[-2.0, 1.0], [1.5, -0.5]], tolerance: 1e-12)
+    expectApproximatelyIdentity(matrix * inverse, tolerance: 1e-12)
 }
+
+@Test func Matrix_BLAS_lapackDeterminantAndInverse() {
+    let matrix = MatrixDenseBLAS<Double>([[4.0, 7.0, 2.0],
+                                          [3.0, 6.0, 1.0],
+                                          [2.0, 5.0, 1.0]])
+
+    #expect(matrix.det.isApproximatelyEqual(to: 3.0, relativeTolerance: 1e-12))
+    expectApproximatelyIdentity(matrix * matrix.inverse(), tolerance: 1e-12)
+}
+
+@Test func Matrix_BLAS_lapackSingularDeterminant() {
+    let matrix = MatrixDenseBLAS<Double>([[1.0, 2.0],
+                                          [2.0, 4.0]])
+
+    #expect(matrix.det == 0.0)
+}
+
+@Test func Matrix_BLAS_lapackFloatDeterminantAndInverse() {
+    let matrix = MatrixDenseBLAS<Float>([[4.0, 7.0, 2.0],
+                                         [3.0, 6.0, 1.0],
+                                         [2.0, 5.0, 1.0]])
+
+    #expect(matrix.det.isApproximatelyEqual(to: 3.0, relativeTolerance: 1e-5))
+    expectApproximatelyIdentity(matrix * matrix.inverse(), tolerance: 1e-5)
+}
+
+@Test func Matrix_BLAS_lapackComplexDeterminantAndInverse() {
+    let matrix = MatrixDenseBLAS<ComplexDouble>([[ComplexDouble(1.0, 1.0), ComplexDouble(2.0, 0.0)],
+                                                 [ComplexDouble(0.0, 0.0), ComplexDouble(3.0, -1.0)]])
+
+    #expect((matrix.det - ComplexDouble(4.0, 2.0)).mod.isApproximatelyEqual(to: 0.0, relativeTolerance: 1e-12))
+    expectApproximatelyIdentity(matrix * matrix.inverse(), tolerance: 1e-12)
+}
+
+@Test func Matrix_BLAS_lapackComplexFloatDeterminantAndInverse() {
+    let matrix = MatrixDenseBLAS<ComplexFloat>([[ComplexFloat(1.0, 1.0), ComplexFloat(2.0, 0.0)],
+                                                [ComplexFloat(0.0, 0.0), ComplexFloat(3.0, -1.0)]])
+
+    #expect((matrix.det - ComplexFloat(4.0, 2.0)).mod.isApproximatelyEqual(to: 0.0, relativeTolerance: 1e-5))
+    expectApproximatelyIdentity(matrix * matrix.inverse(), tolerance: 1e-5)
+}
+
+#if canImport(Accelerate)
+@Test func Matrix_BLAS_lapackImplementationSelection() {
+    let values = [4.0, 3.0, 2.0, 7.0, 6.0, 5.0, 2.0, 1.0, 1.0]
+    let accelerate = MatrixDenseBLAS(rows: 3, columns: 3, values: values, blasImplementation: .accelerate)
+    let openBLAS = MatrixDenseBLAS(rows: 3, columns: 3, values: values, blasImplementation: .openBLAS)
+
+    #expect(accelerate.det.isApproximatelyEqual(to: openBLAS.det, relativeTolerance: 1e-12))
+    #expect(accelerate.inverse().isApproximatelyEqual(to: openBLAS.inverse(), relativeTolerance: 1e-12))
+}
+#endif
 
 extension MatrixImplementation {
     func checkEigenRealEigenvalues() {
@@ -88,4 +140,48 @@ private func complexMatrix<M: MatrixEigen>(_ matrix: M) -> MatrixDenseBLAS<Compl
     MatrixDenseBLAS<ComplexDouble>((0..<matrix.rows).map { row in
         (0..<matrix.columns).map { column in ComplexDouble(matrix[row, column], 0.0) }
     })
+}
+
+private func expectApproximatelyEqual(_ matrix: MatrixDenseBLAS<Double>, _ expected: [[Double]], tolerance: Double) {
+    for row in 0..<matrix.rows {
+        for column in 0..<matrix.columns {
+            #expect(abs(matrix[row, column] - expected[row][column]) <= tolerance)
+        }
+    }
+}
+
+private func expectApproximatelyIdentity(_ matrix: MatrixDenseBLAS<Double>, tolerance: Double) {
+    for row in 0..<matrix.rows {
+        for column in 0..<matrix.columns {
+            let expected = row == column ? 1.0 : 0.0
+            #expect(abs(matrix[row, column] - expected) <= tolerance)
+        }
+    }
+}
+
+private func expectApproximatelyIdentity(_ matrix: MatrixDenseBLAS<Float>, tolerance: Float) {
+    for row in 0..<matrix.rows {
+        for column in 0..<matrix.columns {
+            let expected: Float = row == column ? 1.0 : 0.0
+            #expect(abs(matrix[row, column] - expected) <= tolerance)
+        }
+    }
+}
+
+private func expectApproximatelyIdentity(_ matrix: MatrixDenseBLAS<ComplexDouble>, tolerance: Double) {
+    for row in 0..<matrix.rows {
+        for column in 0..<matrix.columns {
+            let expected = row == column ? ComplexDouble(1.0, 0.0) : .zero
+            #expect((matrix[row, column] - expected).mod <= tolerance)
+        }
+    }
+}
+
+private func expectApproximatelyIdentity(_ matrix: MatrixDenseBLAS<ComplexFloat>, tolerance: Float) {
+    for row in 0..<matrix.rows {
+        for column in 0..<matrix.columns {
+            let expected = row == column ? ComplexFloat(1.0, 0.0) : .zero
+            #expect((matrix[row, column] - expected).mod <= tolerance)
+        }
+    }
 }


### PR DESCRIPTION
## Changes

- Closes #47.
- Added LAPACK getrf/getri wrappers through Accelerate and OpenBLAS.
- Updated MatrixDenseBLAS.det and inverse() to use LAPACK for real and complex scalar types.
- Removed MatrixDenseBLAS temporary MatrixArithmeticReference conformance.
- Added determinant and inverse tests for real, complex, singular, and implementation-selection cases.
- Added determinant and inverse benchmark coverage.