### PR TITLE
Add slice assignment

### DIFF
--- a/Sources/Tensors/Core/PluMatrix.swift
+++ b/Sources/Tensors/Core/PluMatrix.swift
@@ -25,4 +25,51 @@ extension PluMatrix {
             (0..<size).map { column in row == column ? 1 : 0 }
         })
     }
+
+    public subscript(rows: Range<Int>, columns: Range<Int>) -> Self {
+        get { self[TensorSliceIndex.range(rows), TensorSliceIndex.range(columns)] }
+        set { self[TensorSliceIndex.range(rows), TensorSliceIndex.range(columns)] = newValue }
+    }
+
+    public subscript(rows: Range<Int>, columns: TensorSliceIndex) -> Self {
+        get { self[TensorSliceIndex.range(rows), columns] }
+        set { self[TensorSliceIndex.range(rows), columns] = newValue }
+    }
+
+    public subscript(rows: TensorSliceIndex, columns: Range<Int>) -> Self {
+        get { self[rows, TensorSliceIndex.range(columns)] }
+        set { self[rows, TensorSliceIndex.range(columns)] = newValue }
+    }
+
+    public subscript(rows: TensorSliceIndex, columns: TensorSliceIndex) -> Self {
+        get {
+            let rowRange = rows.sliceRange(dimensionSize: self.rows)
+            let columnRange = columns.sliceRange(dimensionSize: self.columns)
+            var result = Self(rows: rowRange.length, columns: columnRange.length, initialValue: .zero)
+            for row in 0..<rowRange.length {
+                for column in 0..<columnRange.length {
+                    let sourceRow = rowRange.start + row * rowRange.step
+                    let sourceColumn = columnRange.start + column * columnRange.step
+                    result[row, column] = self[sourceRow, sourceColumn]
+                }
+            }
+            return result
+        }
+        set {
+            let rowRange = rows.sliceRange(dimensionSize: self.rows)
+            let columnRange = columns.sliceRange(dimensionSize: self.columns)
+            let destinationShape = [rowRange.length, columnRange.length]
+            let error = sliceAssignmentShapeError(destination: destinationShape, replacement: newValue.shape)
+            if let error {
+                preconditionFailure(error)
+            }
+            for row in 0..<rowRange.length {
+                for column in 0..<columnRange.length {
+                    let destinationRow = rowRange.start + row * rowRange.step
+                    let destinationColumn = columnRange.start + column * columnRange.step
+                    self[destinationRow, destinationColumn] = newValue[row, column]
+                }
+            }
+        }
+    }
 }

--- a/Sources/Tensors/Core/PluVector.swift
+++ b/Sources/Tensors/Core/PluVector.swift
@@ -15,6 +15,32 @@ extension PluVector {
     public func toArray() -> [S] {
         return toArray(round: false)
     }
+
+    public subscript(range: Range<Int>) -> Self {
+        get { self[TensorSliceIndex.range(range)] }
+        set { self[TensorSliceIndex.range(range)] = newValue }
+    }
+
+    public subscript(index: TensorSliceIndex) -> Self {
+        get {
+            let range = index.sliceRange(dimensionSize: size)
+            var result = Self(Array(repeating: .zero, count: range.length))
+            for position in 0..<range.length {
+                result[position] = self[range.start + position * range.step]
+            }
+            return result
+        }
+        set {
+            let range = index.sliceRange(dimensionSize: size)
+            let error = sliceAssignmentShapeError(destination: [range.length], replacement: newValue.shape)
+            if let error {
+                preconditionFailure(error)
+            }
+            for position in 0..<range.length {
+                self[range.start + position * range.step] = newValue[position]
+            }
+        }
+    }
 }
 
 extension PluVector {
@@ -29,10 +55,9 @@ extension PluVector {
 
     public func cross<V: PluVector>(_ other: V) -> Self where V.S == S {
         precondition(size == 3 && other.size == 3, "Cross product requires 3D vectors")
-        return Self([
-            self[1] * other[2] - self[2] * other[1],
-            self[2] * other[0] - self[0] * other[2],
-            self[0] * other[1] - self[1] * other[0]
-        ])
+        let x = self[1] * other[2] - self[2] * other[1]
+        let y = self[2] * other[0] - self[0] * other[2]
+        let z = self[0] * other[1] - self[1] * other[0]
+        return Self([x, y, z])
     }
 }

--- a/Sources/Tensors/Matrix/MatrixDenseBLAS.swift
+++ b/Sources/Tensors/Matrix/MatrixDenseBLAS.swift
@@ -128,35 +128,51 @@ extension MatrixDenseBLAS {
     }
 
     public subscript(rows: Range<Int>, columns: Range<Int>) -> MatrixDenseBLAS<S> {
-        slice(rows: SliceRange(rows), columns: SliceRange(columns))
+        get { slice(rows: SliceRange(rows), columns: SliceRange(columns)) }
+        set { view.assign(newValue.view, to: [SliceRange(rows), SliceRange(columns)]) }
     }
 
     public subscript(rows: Range<Int>, columns: TensorSliceIndex) -> MatrixDenseBLAS<S> {
-        slice(rows: SliceRange(rows), columns: columns.sliceRange(dimensionSize: self.columns))
+        get { slice(rows: SliceRange(rows), columns: columns.sliceRange(dimensionSize: self.columns)) }
+        set { view.assign(newValue.view, to: [SliceRange(rows), columns.sliceRange(dimensionSize: self.columns)]) }
     }
 
     public subscript(rows: TensorSliceIndex, columns: Range<Int>) -> MatrixDenseBLAS<S> {
-        slice(rows: rows.sliceRange(dimensionSize: self.rows), columns: SliceRange(columns))
+        get { slice(rows: rows.sliceRange(dimensionSize: self.rows), columns: SliceRange(columns)) }
+        set { view.assign(newValue.view, to: [rows.sliceRange(dimensionSize: self.rows), SliceRange(columns)]) }
     }
 
     public subscript(rows: TensorSliceIndex, columns: TensorSliceIndex) -> MatrixDenseBLAS<S> {
-        slice(rows: rows.sliceRange(dimensionSize: self.rows), columns: columns.sliceRange(dimensionSize: self.columns))
+        get {
+            let rowRange = rows.sliceRange(dimensionSize: self.rows)
+            let columnRange = columns.sliceRange(dimensionSize: self.columns)
+            return slice(rows: rowRange, columns: columnRange)
+        }
+        set {
+            let rowRange = rows.sliceRange(dimensionSize: self.rows)
+            let columnRange = columns.sliceRange(dimensionSize: self.columns)
+            view.assign(newValue.view, to: [rowRange, columnRange])
+        }
     }
 
     public subscript(row: Int, columns: Range<Int>) -> VectorFlatView<S> {
-        slice(row: row, columns: SliceRange(columns))
+        get { slice(row: row, columns: SliceRange(columns)) }
+        set { view.assign(newValue.view, to: [.index(row), TensorSliceIndex.range(columns)]) }
     }
 
     public subscript(row: Int, columns: TensorSliceIndex) -> VectorFlatView<S> {
-        slice(row: row, columns: columns.sliceRange(dimensionSize: self.columns))
+        get { slice(row: row, columns: columns.sliceRange(dimensionSize: self.columns)) }
+        set { view.assign(newValue.view, to: [.index(row), columns]) }
     }
 
     public subscript(rows: Range<Int>, column: Int) -> VectorFlatView<S> {
-        slice(rows: SliceRange(rows), column: column)
+        get { slice(rows: SliceRange(rows), column: column) }
+        set { view.assign(newValue.view, to: [TensorSliceIndex.range(rows), .index(column)]) }
     }
 
     public subscript(rows: TensorSliceIndex, column: Int) -> VectorFlatView<S> {
-        slice(rows: rows.sliceRange(dimensionSize: self.rows), column: column)
+        get { slice(rows: rows.sliceRange(dimensionSize: self.rows), column: column) }
+        set { view.assign(newValue.view, to: [rows, .index(column)]) }
     }
 }
 

--- a/Sources/Tensors/Storage/TensorFlatView.swift
+++ b/Sources/Tensors/Storage/TensorFlatView.swift
@@ -56,7 +56,8 @@ extension TensorFlatView: TensorView {
     }
 
     public subscript(_ indices: TensorSliceIndex...) -> TensorFlatView<Scalar> {
-        slice(indices)
+        get { slice(indices) }
+        set { assign(newValue, to: indices) }
     }
 }
 
@@ -121,6 +122,16 @@ extension TensorFlatView {
         precondition(view.rank == 2, "Tensor slice result must have rank 2")
         return MatrixFlatView(view: view)
     }
+
+    public mutating func assign(_ replacement: TensorFlatView<Scalar>, to indices: [TensorSliceIndex]) {
+        let destination = slice(indices)
+        assign(replacement.elements, replacementShape: replacement.shape, destination: destination)
+    }
+
+    public mutating func assign(_ replacement: TensorFlatView<Scalar>, to ranges: [SliceRange]) {
+        let destination = slice(ranges)
+        assign(replacement.elements, replacementShape: replacement.shape, destination: destination)
+    }
 }
 
 extension TensorFlatView {
@@ -139,6 +150,19 @@ extension TensorFlatView {
             }
         }
         return strides
+    }
+
+    private static func indexCombinations(for shape: [Int]) -> [[Int]] {
+        if shape.isEmpty { return [[]] }
+        if shape.contains(0) { return [] }
+        return (0..<shape.reduce(1, *)).map { flatIndex in
+            var remaining = flatIndex
+            return shape.map { dimension in
+                let index = remaining % dimension
+                remaining /= dimension
+                return index
+            }
+        }
     }
 
     private func linearIndex(_ indices: [Int]) -> Int {
@@ -167,9 +191,27 @@ extension TensorFlatView {
         }
     }
 
+    private mutating func assign(_ replacementElements: [Scalar], replacementShape: [Int],
+                                 destination: TensorFlatView<Scalar>) {
+        let error = sliceAssignmentShapeError(destination: destination.shape, replacement: replacementShape)
+        if let error {
+            preconditionFailure(error)
+        }
+        ensureUniqueStorage()
+        for (index, element) in zip(Self.indexCombinations(for: destination.shape), replacementElements) {
+            let linearIndex = destination.offset + zip(index, destination.strides).map(*).reduce(0, +)
+            storage[linearIndex] = element
+        }
+    }
+
     private mutating func ensureUniqueStorage() {
         if !isKnownUniquelyReferenced(&storage) {
             storage = TensorStorage(storage.elements)
         }
     }
+}
+
+func sliceAssignmentShapeError(destination: [Int], replacement: [Int]) -> String? {
+    if destination == replacement { return nil }
+    return "Assigned slice shape \(replacement) must match destination slice shape \(destination)"
 }

--- a/Sources/Tensors/Tensor/TensorDenseBLAS.swift
+++ b/Sources/Tensors/Tensor/TensorDenseBLAS.swift
@@ -37,6 +37,11 @@ extension TensorDenseBLAS {
         get { self[indices] }
         set { self[indices] = newValue }
     }
+
+    public subscript(_ indices: TensorSliceIndex...) -> TensorDenseBLAS<S> {
+        get { TensorDenseBLAS(view: view.slice(indices)) }
+        set { view.assign(newValue.view, to: indices) }
+    }
 }
 
 // MARK: - TensorMultiplication

--- a/Sources/Tensors/Tensor/TensorDenseReference.swift
+++ b/Sources/Tensors/Tensor/TensorDenseReference.swift
@@ -51,6 +51,27 @@ extension TensorDenseReference {
         set { self[indices] = newValue }
     }
 
+    public subscript(_ indices: TensorSliceIndex...) -> TensorDenseReference<S> {
+        get {
+            let mapping = Self.sliceMapping(indices, shape: shape)
+            var result = TensorDenseReference(shape: mapping.shape, initialValue: .zero)
+            for index in Self.indexCombinations(for: mapping.shape) {
+                result[index] = self[mapping.sourceIndex(index)]
+            }
+            return result
+        }
+        set {
+            let mapping = Self.sliceMapping(indices, shape: shape)
+            let error = sliceAssignmentShapeError(destination: mapping.shape, replacement: newValue.shape)
+            if let error {
+                preconditionFailure(error)
+            }
+            for index in Self.indexCombinations(for: mapping.shape) {
+                self[mapping.sourceIndex(index)] = newValue[index]
+            }
+        }
+    }
+
     public func toNestedArray() -> TensorNestedArray<S> { storage }
 }
 
@@ -104,5 +125,36 @@ extension TensorDenseReference {
                 return index
             }
         }
+    }
+
+    private static func sliceMapping(
+        _ indices: [TensorSliceIndex],
+        shape: [Int]
+    ) -> (shape: [Int], sourceIndex: ([Int]) -> [Int]) {
+        precondition(indices.count == shape.count, "Slice rank must match tensor rank")
+        var resultShape: [Int] = []
+        var dimensions: [(fixed: Int?, range: SliceRange?)] = []
+        for (dimension, index) in indices.enumerated() {
+            switch index {
+            case .index:
+                dimensions.append((index.fixedIndex(dimensionSize: shape[dimension]), nil))
+            case .range, .step, .all:
+                let range = index.sliceRange(dimensionSize: shape[dimension])
+                let lastIndex = range.start + (range.length - 1) * range.step
+                precondition(range.start <= shape[dimension], "Slice start is out of bounds")
+                precondition(range.length == 0 || lastIndex < shape[dimension], "Slice end is out of bounds")
+                resultShape.append(range.length)
+                dimensions.append((nil, range))
+            }
+        }
+        return (resultShape, { resultIndex in
+            var resultPosition = 0
+            return dimensions.map { dimension in
+                if let fixed = dimension.fixed { return fixed }
+                let range = dimension.range!
+                defer { resultPosition += 1 }
+                return range.start + resultIndex[resultPosition] * range.step
+            }
+        })
     }
 }

--- a/Tests/TensorsTests/MatrixDenseTests.swift
+++ b/Tests/TensorsTests/MatrixDenseTests.swift
@@ -102,6 +102,13 @@ enum MatrixImplementation: CaseIterable, CustomStringConvertible {
         case .blas: verifyArithmetic(MatrixDenseBLAS<Double>.self)
         }
     }
+
+    func checkSliceAssignment() {
+        switch self {
+        case .reference: verifySliceAssignment(MatrixDenseReference<Double>.self)
+        case .blas: verifySliceAssignment(MatrixDenseBLAS<Double>.self)
+        }
+    }
 }
 
 @Test(arguments: MatrixImplementation.allCases)
@@ -169,6 +176,23 @@ func MatrixDense_arithmetic(implementation: MatrixImplementation) {
     implementation.checkArithmetic()
 }
 
+@Test(arguments: MatrixImplementation.allCases)
+func MatrixDense_sliceAssignment(implementation: MatrixImplementation) {
+    implementation.checkSliceAssignment()
+}
+
+@Test func MatrixDense_sliceAssignmentReportsShapeMismatch() {
+    #expect(sliceAssignmentShapeError(destination: [2, 2], replacement: [2, 1]) ==
+            "Assigned slice shape [2, 1] must match destination slice shape [2, 2]")
+}
+
+@Test func DefaultMatrix_sliceAssignment() {
+    var matrix = Matrix<Double>([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]])
+    matrix[0..<2, 1..<3] = Matrix<Double>([[20.0, 30.0], [50.0, 60.0]])
+
+    #expect(matrix.toArray() == [[1.0, 20.0, 30.0], [4.0, 50.0, 60.0], [7.0, 8.0, 9.0]])
+}
+
 private func verifyInitializerWithValues<M: PluMatrix>(_ type: M.Type) where M.S == Double {
     var matrix = M([[1.0, 2.0], [3.0, 4.0]])
     #expect(matrix[0, 0] == 1.0)
@@ -199,6 +223,14 @@ private func verifyNestedArrayInitializer<M: PluMatrix>(_ type: M.Type) where M.
     #expect(matrix.shape == [2, 3])
     #expect(matrix.rank == 2)
     #expect(matrix.toArray() == [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+}
+
+private func verifySliceAssignment<M: PluMatrix>(_ type: M.Type) where M.S == Double {
+    var matrix = M([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]])
+    matrix[0..<2, 1..<3] = M([[20.0, 30.0], [50.0, 60.0]])
+    matrix[all, 0..<1] = M([[10.0], [40.0], [70.0]])
+
+    #expect(matrix.toArray() == [[10.0, 20.0, 30.0], [40.0, 50.0, 60.0], [70.0, 8.0, 9.0]])
 }
 
 private func verifyVectorMultiplication<M: PluMatrix>(_ type: M.Type) where M.S == Double {

--- a/Tests/TensorsTests/TensorDenseTests.swift
+++ b/Tests/TensorsTests/TensorDenseTests.swift
@@ -4,6 +4,7 @@ import Testing
 protocol TensorDenseTestImplementation: TensorArithmetic, TensorMultiplication where S == Double {
     init(shape: [Int], initialValue: Double)
     init(shape: [Int], elements: [Double])
+    subscript(_ indices: TensorSliceIndex...) -> Self { get set }
     func flatten() -> [Double]
 }
 
@@ -90,6 +91,13 @@ enum TensorImplementation: CaseIterable, CustomStringConvertible {
         case .blas: verifyPermute(TensorDenseBLAS<Double>.self)
         }
     }
+
+    func checkSliceAssignment() {
+        switch self {
+        case .reference: verifySliceAssignment(TensorDenseReference<Double>.self)
+        case .blas: verifySliceAssignment(TensorDenseBLAS<Double>.self)
+        }
+    }
 }
 
 @Test(arguments: TensorImplementation.allCases)
@@ -140,6 +148,11 @@ func TensorDense_permute(implementation: TensorImplementation) {
     implementation.checkPermute()
 }
 
+@Test(arguments: TensorImplementation.allCases)
+func TensorDense_sliceAssignment(implementation: TensorImplementation) {
+    implementation.checkSliceAssignment()
+}
+
 private func verifyInitializesWithValue<T: TensorDenseTestImplementation>(_ type: T.Type) {
     let tensor = T(shape: [2, 3], initialValue: 2.0)
     #expect(tensor.shape == [2, 3])
@@ -186,6 +199,19 @@ private func verifyFlatArrayRoundTrip<T: TensorDenseTestImplementation>(_ type: 
     #expect(tensor[[1, 2, 1]] == 0.0)
     #expect(tensor.flatten() == elements)
     #expect(copy == tensor)
+}
+
+private func verifySliceAssignment<T: TensorDenseTestImplementation>(_ type: T.Type) {
+    var tensor = T(shape: [2, 3, 2], elements: [
+        1.0, -1.0, 2.0, -2.0, 3.0, -3.0, 0.0, 1.0, -2.0, 2.0, 3.0, 0.0
+    ])
+    tensor[all, range(1..<3), 0] = T(shape: [2, 2], elements: [20.0, 30.0, 40.0, 50.0])
+
+    #expect(tensor[[0, 1, 0]] == 20.0)
+    #expect(tensor[[1, 1, 0]] == 30.0)
+    #expect(tensor[[0, 2, 0]] == 40.0)
+    #expect(tensor[[1, 2, 0]] == 50.0)
+    #expect(tensor[[0, 1, 1]] == -2.0)
 }
 
 private func verifyRankZeroTensors<T: TensorDenseTestImplementation>(_ type: T.Type) {

--- a/Tests/TensorsTests/VectorTests.swift
+++ b/Tests/TensorsTests/VectorTests.swift
@@ -70,6 +70,13 @@ enum VectorImplementation: CaseIterable, CustomStringConvertible {
         case .blas: verifyTensorStructure(VectorDenseBLAS<Double>.self)
         }
     }
+
+    func checkSliceAssignment() {
+        switch self {
+        case .reference: verifySliceAssignment(VectorDenseReference<Double>.self)
+        case .blas: verifySliceAssignment(VectorDenseBLAS<Double>.self)
+        }
+    }
 }
 
 @Test(arguments: VectorImplementation.allCases)
@@ -97,6 +104,9 @@ func VectorDense_toArray(implementation: VectorImplementation) { implementation.
 
 @Test(arguments: VectorImplementation.allCases)
 func VectorDense_tensorStructure(implementation: VectorImplementation) { implementation.checkTensorStructure() }
+
+@Test(arguments: VectorImplementation.allCases)
+func VectorDense_sliceAssignment(implementation: VectorImplementation) { implementation.checkSliceAssignment() }
 
 @Test func DefaultVector_aliasUsesRecommendedImplementation() {
     let vector = Vector<Double>([1.0, 2.0, 3.0])
@@ -131,6 +141,14 @@ private func verifyNestedArrayInitializer<V: PluVector>(_ type: V.Type) where V.
     #expect(vector.shape == [3])
     #expect(vector.rank == 1)
     #expect(vector.toArray() == [1.0, -2.0, 3.0])
+}
+
+private func verifySliceAssignment<V: PluVector>(_ type: V.Type) where V.S == Double {
+    var vector = V([1.0, 2.0, 3.0, 4.0])
+    vector[1..<3] = V([20.0, 30.0])
+    vector[step(0..<4, by: 2)] = V([10.0, 40.0])
+
+    #expect(vector.toArray() == [10.0, 20.0, 40.0, 4.0])
 }
 
 private func verifyPhysicsOperations<V: PluVector>(_ type: V.Type) where V.S == Double {


### PR DESCRIPTION
Closes #56

## Changes
- Add mutable slice assignment for vectors, matrices, and dense tensors.
- Add shape validation for assigned slices.
- Support slice assignment through the default vector and matrix aliases.
- Add small tests for vector, matrix, tensor, alias, and shape-mismatch behavior.