### PR TITLE
Improve slice performance

### DIFF
--- a/Sources/Tensors/Storage/TensorFlatView.swift
+++ b/Sources/Tensors/Storage/TensorFlatView.swift
@@ -22,7 +22,9 @@ extension TensorFlatView: TensorView {
     public var count: Int { shape.reduce(1, *) }
     public var elements: [Scalar] { flattenedElements() }
     public var isContiguous: Bool { strides == Self.columnMajorStrides(for: shape) }
-    public var contiguousElements: [Scalar]? { isContiguous && offset == 0 ? storage.elements : nil }
+    public var contiguousElements: [Scalar]? {
+        isContiguous && offset == 0 && storage.elements.count == count ? storage.elements : nil
+    }
 
     public init(shape: [Int]) {
         precondition(shape.allSatisfy { $0 >= 0 }, "Tensor shape dimensions must be non-negative")

--- a/Sources/Tensors/Storage/TensorFlatView.swift
+++ b/Sources/Tensors/Storage/TensorFlatView.swift
@@ -148,8 +148,25 @@ extension TensorFlatView {
         }
     }
 
+    mutating func assign(_ lazy: LazyTensor<Scalar>, to indices: [TensorSliceIndex]) {
+        var destination = slice(indices)
+        let error = sliceAssignmentShapeError(destination: destination.shape, replacement: lazy.shape)
+        if let error { preconditionFailure(error) }
+        ensureUniqueStorage()
+        destination.storage = storage
+        lazy.assign(to: &destination)
+    }
+
     func value(index0: Int, index1: Int) -> Scalar {
         storage.elements[offset + index0 * strides[0] + index1 * strides[1]]
+    }
+
+    func storageIndex(forUncheckedIndex index: [Int]) -> Int {
+        var linearIndex = offset
+        for dimension in 0..<rank {
+            linearIndex += index[dimension] * strides[dimension]
+        }
+        return linearIndex
     }
 
     mutating func setValue(_ value: Scalar, index0: Int, index1: Int) {
@@ -198,7 +215,7 @@ extension TensorFlatView {
         elements.reserveCapacity(count)
         var index = Array(repeating: 0, count: rank)
         for _ in 0..<count {
-            elements.append(storage.elements[linearIndex(forUncheckedIndex: index)])
+            elements.append(storage.elements[storageIndex(forUncheckedIndex: index)])
             Self.increment(&index, shape: shape)
         }
         return elements
@@ -216,8 +233,8 @@ extension TensorFlatView {
         }
         var index = Array(repeating: 0, count: destination.rank)
         for _ in 0..<destination.count {
-            let element = replacement.storage.elements[replacement.linearIndex(forUncheckedIndex: index)]
-            storage[destination.linearIndex(forUncheckedIndex: index)] = element
+            let element = replacement.storage.elements[replacement.storageIndex(forUncheckedIndex: index)]
+            storage[destination.storageIndex(forUncheckedIndex: index)] = element
             Self.increment(&index, shape: destination.shape)
         }
     }
@@ -254,14 +271,6 @@ extension TensorFlatView {
                 }
             }
         }
-    }
-
-    private func linearIndex(forUncheckedIndex index: [Int]) -> Int {
-        var linearIndex = offset
-        for dimension in 0..<rank {
-            linearIndex += index[dimension] * strides[dimension]
-        }
-        return linearIndex
     }
 
     private static func increment(_ index: inout [Int], shape: [Int]) {

--- a/Sources/Tensors/Tensor/LazyTensor.swift
+++ b/Sources/Tensors/Tensor/LazyTensor.swift
@@ -42,28 +42,30 @@ struct LazyTensor<S: PluScalar> {
 
     func materializedElements() -> [S] {
         var elements: [S] = []
-        elements.reserveCapacity(shape.reduce(1, *))
-        for index in indexCombinations(for: shape) { elements.append(value(index)) }
+        let count = shape.reduce(1, *)
+        elements.reserveCapacity(count)
+        var index = Array(repeating: 0, count: shape.count)
+        for _ in 0..<count {
+            elements.append(value(index))
+            Self.increment(&index, shape: shape)
+        }
         return elements
     }
 
     func assign(to destination: inout TensorFlatView<S>) {
         precondition(destination.shape == shape, "Assigned slice shape \(shape) must match destination slice shape")
-        for index in indexCombinations(for: shape) {
+        var index = Array(repeating: 0, count: shape.count)
+        for _ in 0..<shape.reduce(1, *) {
             destination.storage.elements[destination.storageIndex(forUncheckedIndex: index)] = value(index)
+            Self.increment(&index, shape: shape)
         }
     }
 
-    private func indexCombinations(for shape: [Int]) -> [[Int]] {
-        if shape.isEmpty { return [[]] }
-        if shape.contains(0) { return [] }
-        return (0..<shape.reduce(1, *)).map { flatIndex in
-            var remaining = flatIndex
-            return shape.map { dimension in
-                let index = remaining % dimension
-                remaining /= dimension
-                return index
-            }
+    private static func increment(_ index: inout [Int], shape: [Int]) {
+        for dimension in 0..<shape.count {
+            index[dimension] += 1
+            if index[dimension] < shape[dimension] { return }
+            index[dimension] = 0
         }
     }
 }

--- a/Sources/Tensors/Tensor/LazyTensor.swift
+++ b/Sources/Tensors/Tensor/LazyTensor.swift
@@ -1,0 +1,69 @@
+struct LazyTensor<S: PluScalar> {
+    struct Term {
+        let coefficient: S
+        let view: TensorFlatView<S>
+    }
+
+    let terms: [Term]
+    var shape: [Int] { terms[0].view.shape }
+
+    init(terms: [Term]) {
+        precondition(!terms.isEmpty, "Lazy tensor must contain at least one term")
+        let shape = terms[0].view.shape
+        precondition(terms.allSatisfy { $0.view.shape == shape }, "Lazy tensor terms must have the same shape")
+        self.terms = terms
+    }
+
+    static func view(_ view: TensorFlatView<S>) -> LazyTensor<S> {
+        LazyTensor(terms: [Term(coefficient: 1, view: view)])
+    }
+
+    func adding(_ other: LazyTensor<S>) -> LazyTensor<S> {
+        precondition(shape == other.shape, "Tensors must have the same shape")
+        return LazyTensor(terms: terms + other.terms)
+    }
+
+    func subtracting(_ other: LazyTensor<S>) -> LazyTensor<S> {
+        precondition(shape == other.shape, "Tensors must have the same shape")
+        return LazyTensor(terms: terms + other.terms.map { Term(coefficient: S.zero - $0.coefficient, view: $0.view) })
+    }
+
+    func scaled(by scalar: S) -> LazyTensor<S> {
+        LazyTensor(terms: terms.map { Term(coefficient: scalar * $0.coefficient, view: $0.view) })
+    }
+
+    func value(_ index: [Int]) -> S {
+        var result = S.zero
+        for term in terms {
+            result += term.coefficient * term.view.storage.elements[term.view.storageIndex(forUncheckedIndex: index)]
+        }
+        return result
+    }
+
+    func materializedElements() -> [S] {
+        var elements: [S] = []
+        elements.reserveCapacity(shape.reduce(1, *))
+        for index in indexCombinations(for: shape) { elements.append(value(index)) }
+        return elements
+    }
+
+    func assign(to destination: inout TensorFlatView<S>) {
+        precondition(destination.shape == shape, "Assigned slice shape \(shape) must match destination slice shape")
+        for index in indexCombinations(for: shape) {
+            destination.storage.elements[destination.storageIndex(forUncheckedIndex: index)] = value(index)
+        }
+    }
+
+    private func indexCombinations(for shape: [Int]) -> [[Int]] {
+        if shape.isEmpty { return [[]] }
+        if shape.contains(0) { return [] }
+        return (0..<shape.reduce(1, *)).map { flatIndex in
+            var remaining = flatIndex
+            return shape.map { dimension in
+                let index = remaining % dimension
+                remaining /= dimension
+                return index
+            }
+        }
+    }
+}

--- a/Sources/Tensors/Tensor/TensorDenseBLAS.swift
+++ b/Sources/Tensors/Tensor/TensorDenseBLAS.swift
@@ -16,12 +16,16 @@ private struct TensorDenseContractionPlan {
 
 public struct TensorDenseBLAS<S: PluScalar>: TensorArithmeticBLAS, Equatable {
     private var view: TensorFlatView<S>
+    var lazy: LazyTensor<S>?
 
     public var shape: [Int] { view.shape }
     public var rank: Int { view.rank }
     public var elements: [S] {
-        get { view.contiguousElements ?? view.elements }
-        set { view = TensorFlatView(shape: shape, elements: newValue) }
+        get { lazy?.materializedElements() ?? view.contiguousElements ?? view.elements }
+        set {
+            view = TensorFlatView(shape: shape, elements: newValue)
+            lazy = nil
+        }
     }
 }
 
@@ -34,19 +38,29 @@ extension TensorDenseBLAS: TensorStructure {
 
     public init(shape: [Int], initialValue: S = .zero) {
         self.view = TensorFlatView(shape: shape, elements: Array(repeating: initialValue, count: shape.reduce(1, *)))
+        self.lazy = nil
     }
 
     public init(shape: [Int], elements: [S]) {
         self.view = TensorFlatView(shape: shape, elements: elements)
+        self.lazy = nil
     }
 }
 
 extension TensorDenseBLAS {
+    init(shape: [Int], lazy: LazyTensor<S>) {
+        self.view = TensorFlatView(shape: shape)
+        self.lazy = lazy
+    }
+
     public func flatten() -> [S] { elements }
 
     public subscript(_ indices: [Int]) -> S {
-        get { view[indices] }
-        set { view[indices] = newValue }
+        get { lazy?.value(indices) ?? view[indices] }
+        set {
+            materialize()
+            view[indices] = newValue
+        }
     }
 
     public subscript(_ indices: Int...) -> S {
@@ -55,8 +69,29 @@ extension TensorDenseBLAS {
     }
 
     public subscript(_ indices: TensorSliceIndex...) -> TensorDenseBLAS<S> {
-        get { TensorDenseBLAS(view: view.slice(indices)) }
-        set { view.assign(newValue.view, to: indices) }
+        get {
+            let source = materializedView()
+            return TensorDenseBLAS(view: source.slice(indices), lazy: nil)
+        }
+        set {
+            materialize()
+            if let lazy = newValue.lazy {
+                view.assign(lazy, to: indices)
+            } else {
+                view.assign(newValue.view, to: indices)
+            }
+        }
+    }
+
+    private func materializedView() -> TensorFlatView<S> {
+        if let lazy { return TensorFlatView(shape: shape, elements: lazy.materializedElements()) }
+        return view
+    }
+
+    private mutating func materialize() {
+        guard let lazy else { return }
+        view = TensorFlatView(shape: shape, elements: lazy.materializedElements())
+        self.lazy = nil
     }
 }
 
@@ -154,15 +189,11 @@ extension TensorDenseBLAS {
                 as! TensorDenseBLAS<S>
         }
         if S.self == ComplexDouble.self {
-            return TensorDenseBLAS<ComplexDouble>(shape: lhs.shape,
-                                                  elements: BLASComplexStorage.sum(lhs.elements as! [ComplexDouble],
-                                                                                  rhs.elements as! [ComplexDouble]))
-                as! TensorDenseBLAS<S>
+            return complexDoubleTensorSum(lhs as! TensorDenseBLAS<ComplexDouble>,
+                                          rhs as! TensorDenseBLAS<ComplexDouble>) as! TensorDenseBLAS<S>
         }
         if S.self == ComplexFloat.self {
-            return TensorDenseBLAS<ComplexFloat>(shape: lhs.shape,
-                                                 elements: BLASComplexStorage.sum(lhs.elements as! [ComplexFloat],
-                                                                                rhs.elements as! [ComplexFloat]))
+            return complexFloatTensorSum(lhs as! TensorDenseBLAS<ComplexFloat>, rhs as! TensorDenseBLAS<ComplexFloat>)
                 as! TensorDenseBLAS<S>
         }
         fatalError("Unsupported scalar type")
@@ -178,9 +209,15 @@ extension TensorDenseBLAS {
             return floatTensorDifference(lhs as! TensorDenseBLAS<Float>, rhs as! TensorDenseBLAS<Float>)
                 as! TensorDenseBLAS<S>
         }
-        var result = lhs
-        for index in 0..<lhs.elements.count { result.elements[index] = lhs.elements[index] - rhs.elements[index] }
-        return result
+        if S.self == ComplexDouble.self {
+            return complexDoubleTensorDifference(lhs as! TensorDenseBLAS<ComplexDouble>,
+                                                 rhs as! TensorDenseBLAS<ComplexDouble>) as! TensorDenseBLAS<S>
+        }
+        if S.self == ComplexFloat.self {
+            return complexFloatTensorDifference(lhs as! TensorDenseBLAS<ComplexFloat>,
+                                                rhs as! TensorDenseBLAS<ComplexFloat>) as! TensorDenseBLAS<S>
+        }
+        fatalError("Unsupported scalar type")
     }
 
     public static prefix func - (operand: TensorDenseBLAS<S>) -> TensorDenseBLAS<S> {
@@ -196,15 +233,11 @@ extension TensorDenseBLAS {
             return floatTensorScale(tensor as! TensorDenseBLAS<Float>, by: scalar as! Float) as! TensorDenseBLAS<S>
         }
         if S.self == ComplexDouble.self {
-            return TensorDenseBLAS<ComplexDouble>(shape: tensor.shape,
-                                                  elements: complexDoubleScale(tensor.elements as! [ComplexDouble],
-                                                                                   by: scalar as! ComplexDouble))
+            return complexDoubleTensorScale(tensor as! TensorDenseBLAS<ComplexDouble>, by: scalar as! ComplexDouble)
                 as! TensorDenseBLAS<S>
         }
         if S.self == ComplexFloat.self {
-            return TensorDenseBLAS<ComplexFloat>(shape: tensor.shape,
-                                                 elements: complexFloatScale(tensor.elements as! [ComplexFloat],
-                                                                                  by: scalar as! ComplexFloat))
+            return complexFloatTensorScale(tensor as! TensorDenseBLAS<ComplexFloat>, by: scalar as! ComplexFloat)
                 as! TensorDenseBLAS<S>
         }
         fatalError("Unsupported scalar type")
@@ -220,7 +253,7 @@ extension TensorDenseBLAS {
     }
 
     public static func == (left: TensorDenseBLAS<S>, right: TensorDenseBLAS<S>) -> Bool {
-        left.view == right.view
+        left.shape == right.shape && left.elements == right.elements
     }
 }
 
@@ -306,15 +339,12 @@ public func + (lhs: TensorDenseBLAS<Float>, rhs: TensorDenseBLAS<Float>) -> Tens
 
 public func + (lhs: TensorDenseBLAS<ComplexDouble>, rhs: TensorDenseBLAS<ComplexDouble>)
     -> TensorDenseBLAS<ComplexDouble> {
-    precondition(lhs.shape == rhs.shape, "Tensors must have the same shape")
-    return TensorDenseBLAS<ComplexDouble>(shape: lhs.shape,
-                                          elements: BLASComplexStorage.sum(lhs.elements, rhs.elements))
+    complexDoubleTensorSum(lhs, rhs)
 }
 
 public func + (lhs: TensorDenseBLAS<ComplexFloat>, rhs: TensorDenseBLAS<ComplexFloat>)
     -> TensorDenseBLAS<ComplexFloat> {
-    precondition(lhs.shape == rhs.shape, "Tensors must have the same shape")
-    return TensorDenseBLAS<ComplexFloat>(shape: lhs.shape, elements: BLASComplexStorage.sum(lhs.elements, rhs.elements))
+    complexFloatTensorSum(lhs, rhs)
 }
 
 public func - (lhs: TensorDenseBLAS<Double>, rhs: TensorDenseBLAS<Double>) -> TensorDenseBLAS<Double> {
@@ -327,16 +357,12 @@ public func - (lhs: TensorDenseBLAS<Float>, rhs: TensorDenseBLAS<Float>) -> Tens
 
 public func - (lhs: TensorDenseBLAS<ComplexDouble>, rhs: TensorDenseBLAS<ComplexDouble>)
     -> TensorDenseBLAS<ComplexDouble> {
-    precondition(lhs.shape == rhs.shape, "Tensors must have the same shape")
-    return TensorDenseBLAS<ComplexDouble>(shape: lhs.shape,
-                                          elements: BLASComplexStorage.difference(lhs.elements, rhs.elements))
+    complexDoubleTensorDifference(lhs, rhs)
 }
 
 public func - (lhs: TensorDenseBLAS<ComplexFloat>, rhs: TensorDenseBLAS<ComplexFloat>)
     -> TensorDenseBLAS<ComplexFloat> {
-    precondition(lhs.shape == rhs.shape, "Tensors must have the same shape")
-    return TensorDenseBLAS<ComplexFloat>(shape: lhs.shape,
-                                         elements: BLASComplexStorage.difference(lhs.elements, rhs.elements))
+    complexFloatTensorDifference(lhs, rhs)
 }
 
 public prefix func - (operand: TensorDenseBLAS<Double>) -> TensorDenseBLAS<Double> {
@@ -380,7 +406,7 @@ public func / (tensor: TensorDenseBLAS<Float>, scalar: Float) -> TensorDenseBLAS
 }
 
 public func * (tensor: TensorDenseBLAS<ComplexDouble>, scalar: ComplexDouble) -> TensorDenseBLAS<ComplexDouble> {
-    TensorDenseBLAS<ComplexDouble>(shape: tensor.shape, elements: complexDoubleScale(tensor.elements, by: scalar))
+    complexDoubleTensorScale(tensor, by: scalar)
 }
 
 public func * (scalar: ComplexDouble, tensor: TensorDenseBLAS<ComplexDouble>) -> TensorDenseBLAS<ComplexDouble> {
@@ -392,7 +418,7 @@ public func / (tensor: TensorDenseBLAS<ComplexDouble>, scalar: ComplexDouble) ->
 }
 
 public func * (tensor: TensorDenseBLAS<ComplexFloat>, scalar: ComplexFloat) -> TensorDenseBLAS<ComplexFloat> {
-    TensorDenseBLAS<ComplexFloat>(shape: tensor.shape, elements: complexFloatScale(tensor.elements, by: scalar))
+    complexFloatTensorScale(tensor, by: scalar)
 }
 
 public func * (scalar: ComplexFloat, tensor: TensorDenseBLAS<ComplexFloat>) -> TensorDenseBLAS<ComplexFloat> {
@@ -407,6 +433,9 @@ private func doubleTensorSum(
     _ left: TensorDenseBLAS<Double>, _ right: TensorDenseBLAS<Double>
 ) -> TensorDenseBLAS<Double> {
     precondition(left.shape == right.shape, "Tensors must have the same shape")
+    if !left.isWholeContiguousView || !right.isWholeContiguousView {
+        return TensorDenseBLAS<Double>(shape: left.shape, lazy: left.lazyTensor.adding(right.lazyTensor))
+    }
     return TensorDenseBLAS<Double>(shape: left.shape, elements: doubleSum(left.elements, right.elements))
 }
 
@@ -414,7 +443,30 @@ private func floatTensorSum(
     _ left: TensorDenseBLAS<Float>, _ right: TensorDenseBLAS<Float>
 ) -> TensorDenseBLAS<Float> {
     precondition(left.shape == right.shape, "Tensors must have the same shape")
+    if !left.isWholeContiguousView || !right.isWholeContiguousView {
+        return TensorDenseBLAS<Float>(shape: left.shape, lazy: left.lazyTensor.adding(right.lazyTensor))
+    }
     return TensorDenseBLAS<Float>(shape: left.shape, elements: floatSum(left.elements, right.elements))
+}
+
+private func complexDoubleTensorSum(
+    _ left: TensorDenseBLAS<ComplexDouble>, _ right: TensorDenseBLAS<ComplexDouble>
+) -> TensorDenseBLAS<ComplexDouble> {
+    precondition(left.shape == right.shape, "Tensors must have the same shape")
+    if !left.isWholeContiguousView || !right.isWholeContiguousView {
+        return TensorDenseBLAS<ComplexDouble>(shape: left.shape, lazy: left.lazyTensor.adding(right.lazyTensor))
+    }
+    return TensorDenseBLAS<ComplexDouble>(shape: left.shape, elements: BLASComplexStorage.sum(left.elements, right.elements))
+}
+
+private func complexFloatTensorSum(
+    _ left: TensorDenseBLAS<ComplexFloat>, _ right: TensorDenseBLAS<ComplexFloat>
+) -> TensorDenseBLAS<ComplexFloat> {
+    precondition(left.shape == right.shape, "Tensors must have the same shape")
+    if !left.isWholeContiguousView || !right.isWholeContiguousView {
+        return TensorDenseBLAS<ComplexFloat>(shape: left.shape, lazy: left.lazyTensor.adding(right.lazyTensor))
+    }
+    return TensorDenseBLAS<ComplexFloat>(shape: left.shape, elements: BLASComplexStorage.sum(left.elements, right.elements))
 }
 
 private func doubleTensorDifference(
@@ -422,6 +474,9 @@ private func doubleTensorDifference(
     _ right: TensorDenseBLAS<Double>
 ) -> TensorDenseBLAS<Double> {
     precondition(left.shape == right.shape, "Tensors must have the same shape")
+    if !left.isWholeContiguousView || !right.isWholeContiguousView {
+        return TensorDenseBLAS<Double>(shape: left.shape, lazy: left.lazyTensor.subtracting(right.lazyTensor))
+    }
     return TensorDenseBLAS<Double>(shape: left.shape, elements: doubleDifference(left.elements, right.elements))
 }
 
@@ -430,15 +485,64 @@ private func floatTensorDifference(
     _ right: TensorDenseBLAS<Float>
 ) -> TensorDenseBLAS<Float> {
     precondition(left.shape == right.shape, "Tensors must have the same shape")
+    if !left.isWholeContiguousView || !right.isWholeContiguousView {
+        return TensorDenseBLAS<Float>(shape: left.shape, lazy: left.lazyTensor.subtracting(right.lazyTensor))
+    }
     return TensorDenseBLAS<Float>(shape: left.shape, elements: floatDifference(left.elements, right.elements))
 }
 
+private func complexDoubleTensorDifference(
+    _ left: TensorDenseBLAS<ComplexDouble>, _ right: TensorDenseBLAS<ComplexDouble>
+) -> TensorDenseBLAS<ComplexDouble> {
+    precondition(left.shape == right.shape, "Tensors must have the same shape")
+    if !left.isWholeContiguousView || !right.isWholeContiguousView {
+        return TensorDenseBLAS<ComplexDouble>(shape: left.shape, lazy: left.lazyTensor.subtracting(right.lazyTensor))
+    }
+    return TensorDenseBLAS<ComplexDouble>(shape: left.shape,
+                                          elements: BLASComplexStorage.difference(left.elements, right.elements))
+}
+
+private func complexFloatTensorDifference(
+    _ left: TensorDenseBLAS<ComplexFloat>, _ right: TensorDenseBLAS<ComplexFloat>
+) -> TensorDenseBLAS<ComplexFloat> {
+    precondition(left.shape == right.shape, "Tensors must have the same shape")
+    if !left.isWholeContiguousView || !right.isWholeContiguousView {
+        return TensorDenseBLAS<ComplexFloat>(shape: left.shape, lazy: left.lazyTensor.subtracting(right.lazyTensor))
+    }
+    return TensorDenseBLAS<ComplexFloat>(shape: left.shape,
+                                         elements: BLASComplexStorage.difference(left.elements, right.elements))
+}
+
 private func doubleTensorScale(_ tensor: TensorDenseBLAS<Double>, by scalar: Double) -> TensorDenseBLAS<Double> {
-    TensorDenseBLAS<Double>(shape: tensor.shape, elements: doubleScale(tensor.elements, by: scalar))
+    if !tensor.isWholeContiguousView {
+        return TensorDenseBLAS<Double>(shape: tensor.shape, lazy: tensor.lazyTensor.scaled(by: scalar))
+    }
+    return TensorDenseBLAS<Double>(shape: tensor.shape, elements: doubleScale(tensor.elements, by: scalar))
 }
 
 private func floatTensorScale(_ tensor: TensorDenseBLAS<Float>, by scalar: Float) -> TensorDenseBLAS<Float> {
-    TensorDenseBLAS<Float>(shape: tensor.shape, elements: floatScale(tensor.elements, by: scalar))
+    if !tensor.isWholeContiguousView {
+        return TensorDenseBLAS<Float>(shape: tensor.shape, lazy: tensor.lazyTensor.scaled(by: scalar))
+    }
+    return TensorDenseBLAS<Float>(shape: tensor.shape, elements: floatScale(tensor.elements, by: scalar))
+}
+
+private func complexDoubleTensorScale(
+    _ tensor: TensorDenseBLAS<ComplexDouble>, by scalar: ComplexDouble
+) -> TensorDenseBLAS<ComplexDouble> {
+    if !tensor.isWholeContiguousView {
+        return TensorDenseBLAS<ComplexDouble>(shape: tensor.shape, lazy: tensor.lazyTensor.scaled(by: scalar))
+    }
+    return TensorDenseBLAS<ComplexDouble>(shape: tensor.shape, elements: complexDoubleScale(tensor.elements, by: scalar))
+}
+
+private func complexFloatTensorScale(
+    _ tensor: TensorDenseBLAS<ComplexFloat>, by scalar: ComplexFloat
+) -> TensorDenseBLAS<ComplexFloat> {
+    if !tensor.isWholeContiguousView {
+        return TensorDenseBLAS<ComplexFloat>(shape: tensor.shape, lazy: tensor.lazyTensor.scaled(by: scalar))
+    }
+    return TensorDenseBLAS<ComplexFloat>(shape: tensor.shape, elements: complexFloatScale(tensor.elements, by: scalar))
 }
 
 private func matrixProduct<S: PluScalar>(
@@ -581,6 +685,12 @@ extension TensorDenseBLAS {
             expected += 1
         }
         return expected == rank
+    }
+
+    fileprivate var lazyTensor: LazyTensor<S> { lazy ?? .view(view) }
+
+    fileprivate var isWholeContiguousView: Bool {
+        lazy == nil && view.offset == 0 && view.isContiguous && view.storage.elements.count == shape.reduce(1, *)
     }
 }
 

--- a/Sources/Tensors/Vector/VectorDenseBLAS.swift
+++ b/Sources/Tensors/Vector/VectorDenseBLAS.swift
@@ -5,10 +5,19 @@ import Numerics
 import OpenBLASWrapper
 
 public struct VectorDenseBLAS<S: PluScalar>: TensorArithmeticBLAS {
-    public var elements: [S]
+    var view: TensorFlatView<S>
+    public var elements: [S] {
+        get { view.contiguousElements ?? view.elements }
+        set { view = TensorFlatView(shape: [newValue.count], elements: newValue) }
+    }
 
     public init(_ values: [S]) {
-        self.elements = values
+        self.view = TensorFlatView(shape: [values.count], elements: values)
+    }
+
+    init(view: TensorFlatView<S>) {
+        precondition(view.rank == 1, "VectorDenseBLAS requires rank 1")
+        self.view = view
     }
 }
 
@@ -18,8 +27,8 @@ extension VectorDenseBLAS: PluVector {
     public var size: Int { elements.count }
 
     public subscript(i: Int) -> S {
-        get { elements[i] }
-        set { elements[i] = newValue }
+        get { view[[i]] }
+        set { view[[i]] = newValue }
     }
 
     public subscript(_ indices: [Int]) -> S {
@@ -91,6 +100,16 @@ extension VectorDenseBLAS: PluVector {
 }
 
 extension VectorDenseBLAS {
+    public subscript(range: Range<Int>) -> VectorDenseBLAS<S> {
+        get { VectorDenseBLAS(view: view.slice(SliceRange(range))) }
+        set { view.assign(newValue.view, to: [SliceRange(range)]) }
+    }
+
+    public subscript(index: TensorSliceIndex) -> VectorDenseBLAS<S> {
+        get { VectorDenseBLAS(view: view.slice(index.sliceRange(dimensionSize: size))) }
+        set { view.assign(newValue.view, to: [index]) }
+    }
+
     public static func + (lhs: VectorDenseBLAS<S>, rhs: VectorDenseBLAS<S>) -> VectorDenseBLAS<S> {
         precondition(lhs.shape == rhs.shape, "Tensors must have the same shape")
         if S.self == Double.self {

--- a/Sources/Tensors/Vector/VectorDenseBLAS.swift
+++ b/Sources/Tensors/Vector/VectorDenseBLAS.swift
@@ -6,18 +6,29 @@ import OpenBLASWrapper
 
 public struct VectorDenseBLAS<S: PluScalar>: TensorArithmeticBLAS {
     var view: TensorFlatView<S>
+    var lazy: LazyTensor<S>?
     public var elements: [S] {
-        get { view.contiguousElements ?? view.elements }
-        set { view = TensorFlatView(shape: [newValue.count], elements: newValue) }
+        get { lazy?.materializedElements() ?? view.contiguousElements ?? view.elements }
+        set {
+            view = TensorFlatView(shape: [newValue.count], elements: newValue)
+            lazy = nil
+        }
     }
 
     public init(_ values: [S]) {
         self.view = TensorFlatView(shape: [values.count], elements: values)
+        self.lazy = nil
     }
 
-    init(view: TensorFlatView<S>) {
+    init(view: TensorFlatView<S>, lazy: LazyTensor<S>? = nil) {
         precondition(view.rank == 1, "VectorDenseBLAS requires rank 1")
         self.view = view
+        self.lazy = lazy
+    }
+
+    init(size: Int, lazy: LazyTensor<S>) {
+        self.view = TensorFlatView(shape: [size])
+        self.lazy = lazy
     }
 }
 
@@ -27,8 +38,11 @@ extension VectorDenseBLAS: PluVector {
     public var size: Int { elements.count }
 
     public subscript(i: Int) -> S {
-        get { view[[i]] }
-        set { view[[i]] = newValue }
+        get { lazy?.value([i]) ?? view[[i]] }
+        set {
+            materialize()
+            view[[i]] = newValue
+        }
     }
 
     public subscript(_ indices: [Int]) -> S {
@@ -101,13 +115,38 @@ extension VectorDenseBLAS: PluVector {
 
 extension VectorDenseBLAS {
     public subscript(range: Range<Int>) -> VectorDenseBLAS<S> {
-        get { VectorDenseBLAS(view: view.slice(SliceRange(range))) }
-        set { view.assign(newValue.view, to: [SliceRange(range)]) }
+        get { VectorDenseBLAS(view: materializedView().slice(SliceRange(range))) }
+        set { assign(newValue, to: [TensorSliceIndex.range(range)]) }
     }
 
     public subscript(index: TensorSliceIndex) -> VectorDenseBLAS<S> {
-        get { VectorDenseBLAS(view: view.slice(index.sliceRange(dimensionSize: size))) }
-        set { view.assign(newValue.view, to: [index]) }
+        get { VectorDenseBLAS(view: materializedView().slice(index.sliceRange(dimensionSize: size))) }
+        set { assign(newValue, to: [index]) }
+    }
+
+    private func materializedView() -> TensorFlatView<S> {
+        if let lazy { return TensorFlatView(shape: shape, elements: lazy.materializedElements()) }
+        return view
+    }
+
+    private mutating func materialize() {
+        guard let lazy else { return }
+        view = TensorFlatView(shape: shape, elements: lazy.materializedElements())
+        self.lazy = nil
+    }
+
+    private mutating func assign(_ replacement: VectorDenseBLAS<S>, to indices: [TensorSliceIndex]) {
+        materialize()
+        if let lazy = replacement.lazy {
+            view.assign(lazy, to: indices)
+        } else {
+            view.assign(replacement.view, to: indices)
+        }
+    }
+
+    fileprivate var lazyTensor: LazyTensor<S> { lazy ?? .view(view) }
+    fileprivate var isWholeContiguousView: Bool {
+        lazy == nil && view.offset == 0 && view.isContiguous && view.storage.elements.count == size
     }
 
     public static func + (lhs: VectorDenseBLAS<S>, rhs: VectorDenseBLAS<S>) -> VectorDenseBLAS<S> {
@@ -121,14 +160,12 @@ extension VectorDenseBLAS {
                 as! VectorDenseBLAS<S>
         }
         if S.self == ComplexDouble.self {
-            return VectorDenseBLAS<ComplexDouble>(BLASComplexStorage.sum(lhs.elements as! [ComplexDouble],
-                                                                        rhs.elements as! [ComplexDouble]))
-                as! VectorDenseBLAS<S>
+            return complexDoubleVectorSum(lhs as! VectorDenseBLAS<ComplexDouble>,
+                                          rhs as! VectorDenseBLAS<ComplexDouble>) as! VectorDenseBLAS<S>
         }
         if S.self == ComplexFloat.self {
-            return VectorDenseBLAS<ComplexFloat>(BLASComplexStorage.sum(lhs.elements as! [ComplexFloat],
-                                                                      rhs.elements as! [ComplexFloat]))
-                as! VectorDenseBLAS<S>
+            return complexFloatVectorSum(lhs as! VectorDenseBLAS<ComplexFloat>,
+                                         rhs as! VectorDenseBLAS<ComplexFloat>) as! VectorDenseBLAS<S>
         }
         fatalError("Unsupported scalar type")
     }
@@ -143,9 +180,15 @@ extension VectorDenseBLAS {
             return floatVectorDifference(lhs as! VectorDenseBLAS<Float>, rhs as! VectorDenseBLAS<Float>)
                 as! VectorDenseBLAS<S>
         }
-        var result = lhs
-        for index in 0..<lhs.elements.count { result.elements[index] = lhs.elements[index] - rhs.elements[index] }
-        return result
+        if S.self == ComplexDouble.self {
+            return complexDoubleVectorDifference(lhs as! VectorDenseBLAS<ComplexDouble>,
+                                                 rhs as! VectorDenseBLAS<ComplexDouble>) as! VectorDenseBLAS<S>
+        }
+        if S.self == ComplexFloat.self {
+            return complexFloatVectorDifference(lhs as! VectorDenseBLAS<ComplexFloat>,
+                                                rhs as! VectorDenseBLAS<ComplexFloat>) as! VectorDenseBLAS<S>
+        }
+        fatalError("Unsupported scalar type")
     }
 
     public static prefix func - (operand: VectorDenseBLAS<S>) -> VectorDenseBLAS<S> {
@@ -161,13 +204,11 @@ extension VectorDenseBLAS {
             return floatVectorScale(vector as! VectorDenseBLAS<Float>, by: scalar as! Float) as! VectorDenseBLAS<S>
         }
         if S.self == ComplexDouble.self {
-            return VectorDenseBLAS<ComplexDouble>(complexDoubleScale(vector.elements as! [ComplexDouble],
-                                                                          by: scalar as! ComplexDouble))
+            return complexDoubleVectorScale(vector as! VectorDenseBLAS<ComplexDouble>, by: scalar as! ComplexDouble)
                 as! VectorDenseBLAS<S>
         }
         if S.self == ComplexFloat.self {
-            return VectorDenseBLAS<ComplexFloat>(complexFloatScale(vector.elements as! [ComplexFloat],
-                                                                        by: scalar as! ComplexFloat))
+            return complexFloatVectorScale(vector as! VectorDenseBLAS<ComplexFloat>, by: scalar as! ComplexFloat)
                 as! VectorDenseBLAS<S>
         }
         fatalError("Unsupported scalar type")
@@ -181,6 +222,10 @@ extension VectorDenseBLAS {
         let one: S = 1
         return vector * (one / scalar)
     }
+
+    public static func == (lhs: VectorDenseBLAS<S>, rhs: VectorDenseBLAS<S>) -> Bool {
+        lhs.shape == rhs.shape && lhs.elements == rhs.elements
+    }
 }
 
 public func + (lhs: VectorDenseBLAS<Double>, rhs: VectorDenseBLAS<Double>) -> VectorDenseBLAS<Double> {
@@ -193,14 +238,12 @@ public func + (lhs: VectorDenseBLAS<Float>, rhs: VectorDenseBLAS<Float>) -> Vect
 
 public func + (lhs: VectorDenseBLAS<ComplexDouble>, rhs: VectorDenseBLAS<ComplexDouble>)
     -> VectorDenseBLAS<ComplexDouble> {
-    precondition(lhs.shape == rhs.shape, "Tensors must have the same shape")
-    return VectorDenseBLAS<ComplexDouble>(BLASComplexStorage.sum(lhs.elements, rhs.elements))
+    complexDoubleVectorSum(lhs, rhs)
 }
 
 public func + (lhs: VectorDenseBLAS<ComplexFloat>, rhs: VectorDenseBLAS<ComplexFloat>)
     -> VectorDenseBLAS<ComplexFloat> {
-    precondition(lhs.shape == rhs.shape, "Tensors must have the same shape")
-    return VectorDenseBLAS<ComplexFloat>(BLASComplexStorage.sum(lhs.elements, rhs.elements))
+    complexFloatVectorSum(lhs, rhs)
 }
 
 public func - (lhs: VectorDenseBLAS<Double>, rhs: VectorDenseBLAS<Double>) -> VectorDenseBLAS<Double> {
@@ -213,14 +256,12 @@ public func - (lhs: VectorDenseBLAS<Float>, rhs: VectorDenseBLAS<Float>) -> Vect
 
 public func - (lhs: VectorDenseBLAS<ComplexDouble>, rhs: VectorDenseBLAS<ComplexDouble>)
     -> VectorDenseBLAS<ComplexDouble> {
-    precondition(lhs.shape == rhs.shape, "Tensors must have the same shape")
-    return VectorDenseBLAS<ComplexDouble>(BLASComplexStorage.difference(lhs.elements, rhs.elements))
+    complexDoubleVectorDifference(lhs, rhs)
 }
 
 public func - (lhs: VectorDenseBLAS<ComplexFloat>, rhs: VectorDenseBLAS<ComplexFloat>)
     -> VectorDenseBLAS<ComplexFloat> {
-    precondition(lhs.shape == rhs.shape, "Tensors must have the same shape")
-    return VectorDenseBLAS<ComplexFloat>(BLASComplexStorage.difference(lhs.elements, rhs.elements))
+    complexFloatVectorDifference(lhs, rhs)
 }
 
 public prefix func - (operand: VectorDenseBLAS<Double>) -> VectorDenseBLAS<Double> {
@@ -265,7 +306,7 @@ public func / (vector: VectorDenseBLAS<Float>, scalar: Float) -> VectorDenseBLAS
 
 public func * (vector: VectorDenseBLAS<ComplexDouble>, scalar: ComplexDouble)
     -> VectorDenseBLAS<ComplexDouble> {
-    VectorDenseBLAS<ComplexDouble>(complexDoubleScale(vector.elements, by: scalar))
+    complexDoubleVectorScale(vector, by: scalar)
 }
 
 public func * (scalar: ComplexDouble, vector: VectorDenseBLAS<ComplexDouble>)
@@ -279,7 +320,7 @@ public func / (vector: VectorDenseBLAS<ComplexDouble>, scalar: ComplexDouble)
 }
 
 public func * (vector: VectorDenseBLAS<ComplexFloat>, scalar: ComplexFloat) -> VectorDenseBLAS<ComplexFloat> {
-    VectorDenseBLAS<ComplexFloat>(complexFloatScale(vector.elements, by: scalar))
+    complexFloatVectorScale(vector, by: scalar)
 }
 
 public func * (scalar: ComplexFloat, vector: VectorDenseBLAS<ComplexFloat>) -> VectorDenseBLAS<ComplexFloat> {
@@ -294,6 +335,9 @@ private func doubleVectorSum(
     _ left: VectorDenseBLAS<Double>, _ right: VectorDenseBLAS<Double>
 ) -> VectorDenseBLAS<Double> {
     precondition(left.shape == right.shape, "Tensors must have the same shape")
+    if !left.isWholeContiguousView || !right.isWholeContiguousView {
+        return VectorDenseBLAS<Double>(size: left.size, lazy: left.lazyTensor.adding(right.lazyTensor))
+    }
     return VectorDenseBLAS<Double>(doubleSum(left.elements, right.elements))
 }
 
@@ -301,7 +345,30 @@ private func floatVectorSum(
     _ left: VectorDenseBLAS<Float>, _ right: VectorDenseBLAS<Float>
 ) -> VectorDenseBLAS<Float> {
     precondition(left.shape == right.shape, "Tensors must have the same shape")
+    if !left.isWholeContiguousView || !right.isWholeContiguousView {
+        return VectorDenseBLAS<Float>(size: left.size, lazy: left.lazyTensor.adding(right.lazyTensor))
+    }
     return VectorDenseBLAS<Float>(floatSum(left.elements, right.elements))
+}
+
+private func complexDoubleVectorSum(
+    _ left: VectorDenseBLAS<ComplexDouble>, _ right: VectorDenseBLAS<ComplexDouble>
+) -> VectorDenseBLAS<ComplexDouble> {
+    precondition(left.shape == right.shape, "Tensors must have the same shape")
+    if !left.isWholeContiguousView || !right.isWholeContiguousView {
+        return VectorDenseBLAS<ComplexDouble>(size: left.size, lazy: left.lazyTensor.adding(right.lazyTensor))
+    }
+    return VectorDenseBLAS<ComplexDouble>(BLASComplexStorage.sum(left.elements, right.elements))
+}
+
+private func complexFloatVectorSum(
+    _ left: VectorDenseBLAS<ComplexFloat>, _ right: VectorDenseBLAS<ComplexFloat>
+) -> VectorDenseBLAS<ComplexFloat> {
+    precondition(left.shape == right.shape, "Tensors must have the same shape")
+    if !left.isWholeContiguousView || !right.isWholeContiguousView {
+        return VectorDenseBLAS<ComplexFloat>(size: left.size, lazy: left.lazyTensor.adding(right.lazyTensor))
+    }
+    return VectorDenseBLAS<ComplexFloat>(BLASComplexStorage.sum(left.elements, right.elements))
 }
 
 private func doubleVectorDifference(
@@ -309,6 +376,9 @@ private func doubleVectorDifference(
     _ right: VectorDenseBLAS<Double>
 ) -> VectorDenseBLAS<Double> {
     precondition(left.shape == right.shape, "Tensors must have the same shape")
+    if !left.isWholeContiguousView || !right.isWholeContiguousView {
+        return VectorDenseBLAS<Double>(size: left.size, lazy: left.lazyTensor.subtracting(right.lazyTensor))
+    }
     return VectorDenseBLAS<Double>(doubleDifference(left.elements, right.elements))
 }
 
@@ -317,15 +387,62 @@ private func floatVectorDifference(
     _ right: VectorDenseBLAS<Float>
 ) -> VectorDenseBLAS<Float> {
     precondition(left.shape == right.shape, "Tensors must have the same shape")
+    if !left.isWholeContiguousView || !right.isWholeContiguousView {
+        return VectorDenseBLAS<Float>(size: left.size, lazy: left.lazyTensor.subtracting(right.lazyTensor))
+    }
     return VectorDenseBLAS<Float>(floatDifference(left.elements, right.elements))
 }
 
+private func complexDoubleVectorDifference(
+    _ left: VectorDenseBLAS<ComplexDouble>, _ right: VectorDenseBLAS<ComplexDouble>
+) -> VectorDenseBLAS<ComplexDouble> {
+    precondition(left.shape == right.shape, "Tensors must have the same shape")
+    if !left.isWholeContiguousView || !right.isWholeContiguousView {
+        return VectorDenseBLAS<ComplexDouble>(size: left.size, lazy: left.lazyTensor.subtracting(right.lazyTensor))
+    }
+    return VectorDenseBLAS<ComplexDouble>(BLASComplexStorage.difference(left.elements, right.elements))
+}
+
+private func complexFloatVectorDifference(
+    _ left: VectorDenseBLAS<ComplexFloat>, _ right: VectorDenseBLAS<ComplexFloat>
+) -> VectorDenseBLAS<ComplexFloat> {
+    precondition(left.shape == right.shape, "Tensors must have the same shape")
+    if !left.isWholeContiguousView || !right.isWholeContiguousView {
+        return VectorDenseBLAS<ComplexFloat>(size: left.size, lazy: left.lazyTensor.subtracting(right.lazyTensor))
+    }
+    return VectorDenseBLAS<ComplexFloat>(BLASComplexStorage.difference(left.elements, right.elements))
+}
+
 private func doubleVectorScale(_ vector: VectorDenseBLAS<Double>, by scalar: Double) -> VectorDenseBLAS<Double> {
-    VectorDenseBLAS<Double>(doubleScale(vector.elements, by: scalar))
+    if !vector.isWholeContiguousView {
+        return VectorDenseBLAS<Double>(size: vector.size, lazy: vector.lazyTensor.scaled(by: scalar))
+    }
+    return VectorDenseBLAS<Double>(doubleScale(vector.elements, by: scalar))
 }
 
 private func floatVectorScale(_ vector: VectorDenseBLAS<Float>, by scalar: Float) -> VectorDenseBLAS<Float> {
-    VectorDenseBLAS<Float>(floatScale(vector.elements, by: scalar))
+    if !vector.isWholeContiguousView {
+        return VectorDenseBLAS<Float>(size: vector.size, lazy: vector.lazyTensor.scaled(by: scalar))
+    }
+    return VectorDenseBLAS<Float>(floatScale(vector.elements, by: scalar))
+}
+
+private func complexDoubleVectorScale(
+    _ vector: VectorDenseBLAS<ComplexDouble>, by scalar: ComplexDouble
+) -> VectorDenseBLAS<ComplexDouble> {
+    if !vector.isWholeContiguousView {
+        return VectorDenseBLAS<ComplexDouble>(size: vector.size, lazy: vector.lazyTensor.scaled(by: scalar))
+    }
+    return VectorDenseBLAS<ComplexDouble>(complexDoubleScale(vector.elements, by: scalar))
+}
+
+private func complexFloatVectorScale(
+    _ vector: VectorDenseBLAS<ComplexFloat>, by scalar: ComplexFloat
+) -> VectorDenseBLAS<ComplexFloat> {
+    if !vector.isWholeContiguousView {
+        return VectorDenseBLAS<ComplexFloat>(size: vector.size, lazy: vector.lazyTensor.scaled(by: scalar))
+    }
+    return VectorDenseBLAS<ComplexFloat>(complexFloatScale(vector.elements, by: scalar))
 }
 
 private func doubleMagnitude(_ vector: VectorDenseBLAS<Double>) -> Double {

--- a/Tests/TensorsTests/TensorDenseBLASTests.swift
+++ b/Tests/TensorsTests/TensorDenseBLASTests.swift
@@ -27,6 +27,31 @@ private func tensor(_ values: [[[Double]]]) -> TensorDenseBLAS<Double> {
     #expect(tensor.elements == [1.0, -1.0, 2.0, 0.0, 3.0, -3.0])
 }
 
+@Test func TensorDenseBLAS_sliceArithmeticStaysLazy() {
+    let tensor = TensorDenseBLAS<Double>(shape: [2, 4, 2], elements: [
+        1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0,
+        9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0
+    ])
+    let result = tensor[all, range(0..<2), all] + 2.0 * tensor[all, range(2..<4), all]
+
+    #expect(result.lazy != nil)
+    #expect(result.elements == [11.0, 14.0, 17.0, 20.0, 35.0, 38.0, 41.0, 44.0])
+}
+
+@Test func TensorDenseBLAS_assignsLazySliceArithmetic() {
+    let source = TensorDenseBLAS<Double>(shape: [2, 4, 2], elements: [
+        1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0,
+        9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0
+    ])
+    var destination = TensorDenseBLAS<Double>(shape: [2, 3, 2], initialValue: 0.0)
+    destination[all, range(1..<3), all] = source[all, range(0..<2), all] + 2.0 * source[all, range(2..<4), all]
+
+    #expect(destination.elements == [
+        0.0, 0.0, 11.0, 14.0, 17.0, 20.0,
+        0.0, 0.0, 35.0, 38.0, 41.0, 44.0
+    ])
+}
+
 @Test func TensorDenseBLAS_mixedScalarArithmetic() {
     let realScalar = TensorDenseBLAS<Double>(shape: [], elements: [2.0])
     let realRank3 = TensorDenseBLAS<Double>(shape: [2, 2, 2], elements: [1.0, 0.0, -1.0, 2.0, 3.0, -2.0, 0.0, 1.0])

--- a/Tests/TensorsTests/VectorTests.swift
+++ b/Tests/TensorsTests/VectorTests.swift
@@ -134,6 +134,22 @@ func VectorDense_sliceAssignment(implementation: VectorImplementation) { impleme
     #expect(slice.toArray() == [20.0, 3.0])
 }
 
+@Test func VectorDense_BLAS_sliceArithmeticStaysLazy() {
+    let vector = VectorDenseBLAS<Double>([1.0, 2.0, 3.0, 4.0, 5.0])
+    let result = vector[0..<2] + 2.0 * vector[2..<4]
+
+    #expect(result.lazy != nil)
+    #expect(result.toArray() == [7.0, 10.0])
+}
+
+@Test func VectorDense_BLAS_assignsLazySliceArithmetic() {
+    let source = VectorDenseBLAS<Double>([1.0, 2.0, 3.0, 4.0, 5.0])
+    var destination = VectorDenseBLAS<Double>([0.0, 0.0, 0.0, 0.0])
+    destination[1..<3] = source[0..<2] + 2.0 * source[2..<4]
+
+    #expect(destination.toArray() == [0.0, 7.0, 10.0, 0.0])
+}
+
 private func verifyDoubleInit<V: PluVector>(_ type: V.Type) where V.S == Double {
     let v = V(a)
     #expect(v.size == a.count)

--- a/Tests/TensorsTests/VectorTests.swift
+++ b/Tests/TensorsTests/VectorTests.swift
@@ -115,6 +115,25 @@ func VectorDense_sliceAssignment(implementation: VectorImplementation) { impleme
     #expect(vector.toArray() == [1.0, 2.0, 3.0])
 }
 
+@Test func VectorDense_BLAS_slicesWithoutCopying() {
+    let vector = VectorDenseBLAS<Double>([1.0, 2.0, 3.0, 4.0])
+    let slice = vector[1..<3]
+
+    #expect(slice.view.storage === vector.view.storage)
+    #expect(slice.shape == [2])
+    #expect(slice.toArray() == [2.0, 3.0])
+}
+
+@Test func VectorDense_BLAS_mutatingSliceCopiesOnWrite() {
+    let vector = VectorDenseBLAS<Double>([1.0, 2.0, 3.0, 4.0])
+    var slice = vector[1..<3]
+    slice[0] = 20.0
+
+    #expect(slice.view.storage !== vector.view.storage)
+    #expect(vector.toArray() == [1.0, 2.0, 3.0, 4.0])
+    #expect(slice.toArray() == [20.0, 3.0])
+}
+
 private func verifyDoubleInit<V: PluVector>(_ type: V.Type) where V.S == Double {
     let v = V(a)
     #expect(v.size == a.count)


### PR DESCRIPTION
Closes #60

## Changes
- Make `VectorDenseBLAS` slices view-backed instead of copied.
- Add lazy dense tensor slice arithmetic for add, subtract, and scalar multiply.
- Add lazy dense vector slice arithmetic for add, subtract, and scalar multiply.
- Fix whole-storage detection for offset-zero partial slices.
- Avoid allocating all index combinations while materializing lazy tensor expressions.
- Add tests for view-backed vector slices and lazy tensor/vector slice assignment.