### PR TITLE
Extract lower tensors

### DIFF
--- a/Sources/Tensors/Tensor/TensorDenseBLAS.swift
+++ b/Sources/Tensors/Tensor/TensorDenseBLAS.swift
@@ -55,6 +55,21 @@ extension TensorDenseBLAS {
 
     public func flatten() -> [S] { elements }
 
+    public func asScalar() -> S {
+        precondition(rank == 0, "Scalar extraction requires rank 0")
+        return self[[]]
+    }
+
+    public func asVector() -> VectorDenseBLAS<S> {
+        precondition(rank == 1, "Vector extraction requires rank 1")
+        return VectorDenseBLAS(elements)
+    }
+
+    public func asMatrix() -> MatrixDenseBLAS<S> {
+        precondition(rank == 2, "Matrix extraction requires rank 2")
+        return MatrixDenseBLAS(rows: shape[0], columns: shape[1], values: elements)
+    }
+
     public subscript(_ indices: [Int]) -> S {
         get { lazy?.value(indices) ?? view[indices] }
         set {

--- a/Sources/Tensors/Tensor/TensorDenseReference.swift
+++ b/Sources/Tensors/Tensor/TensorDenseReference.swift
@@ -35,6 +35,21 @@ extension TensorDenseReference: TensorStructure {
 extension TensorDenseReference {
     public func flatten() -> [S] { elements }
 
+    public func asScalar() -> S {
+        precondition(rank == 0, "Scalar extraction requires rank 0")
+        return self[[]]
+    }
+
+    public func asVector() -> VectorDenseReference<S> {
+        precondition(rank == 1, "Vector extraction requires rank 1")
+        return VectorDenseReference(elements)
+    }
+
+    public func asMatrix() -> MatrixDenseReference<S> {
+        precondition(rank == 2, "Matrix extraction requires rank 2")
+        return MatrixDenseReference(rows: shape[0], columns: shape[1], values: elements)
+    }
+
     public subscript(_ indices: [Int]) -> S {
         get {
             precondition(indices.count == rank, "Tensor index rank must match tensor rank")

--- a/Tests/TensorsTests/TensorDenseTests.swift
+++ b/Tests/TensorsTests/TensorDenseTests.swift
@@ -98,6 +98,13 @@ enum TensorImplementation: CaseIterable, CustomStringConvertible {
         case .blas: verifySliceAssignment(TensorDenseBLAS<Double>.self)
         }
     }
+
+    func checkExtractsLowerTensors() {
+        switch self {
+        case .reference: verifyReferenceLowerTensorExtraction()
+        case .blas: verifyBLASLowerTensorExtraction()
+        }
+    }
 }
 
 @Test(arguments: TensorImplementation.allCases)
@@ -151,6 +158,11 @@ func TensorDense_permute(implementation: TensorImplementation) {
 @Test(arguments: TensorImplementation.allCases)
 func TensorDense_sliceAssignment(implementation: TensorImplementation) {
     implementation.checkSliceAssignment()
+}
+
+@Test(arguments: TensorImplementation.allCases)
+func TensorDense_extractsLowerTensors(implementation: TensorImplementation) {
+    implementation.checkExtractsLowerTensors()
 }
 
 @Test func TensorNotation_reportsInvalidMultiplyNotation() {
@@ -276,6 +288,26 @@ private func verifyRankZeroTensors<T: TensorDenseTestImplementation>(_ type: T.T
     #expect(tensor[[]] == 7.0)
     tensor[[]] = -2.0
     #expect(tensor[[]] == -2.0)
+}
+
+private func verifyReferenceLowerTensorExtraction() {
+    let scalar = TensorDenseReference<Double>(shape: [], elements: [3.0]).asScalar()
+    let vector = TensorDenseReference<Double>(shape: [3], elements: [1.0, -2.0, 3.0]).asVector()
+    let matrix = TensorDenseReference<Double>(shape: [2, 2], elements: [1.0, -2.0, 3.0, 0.0]).asMatrix()
+
+    #expect(scalar == 3.0)
+    #expect(vector.toArray(round: false) == [1.0, -2.0, 3.0])
+    #expect(matrix.toArray(round: false) == [[1.0, 3.0], [-2.0, 0.0]])
+}
+
+private func verifyBLASLowerTensorExtraction() {
+    let scalar = TensorDenseBLAS<Double>(shape: [], elements: [3.0]).asScalar()
+    let vector = TensorDenseBLAS<Double>(shape: [3], elements: [1.0, -2.0, 3.0]).asVector()
+    let matrix = TensorDenseBLAS<Double>(shape: [2, 2], elements: [1.0, -2.0, 3.0, 0.0]).asMatrix()
+
+    #expect(scalar == 3.0)
+    #expect(vector.toArray(round: false) == [1.0, -2.0, 3.0])
+    #expect(matrix.toArray(round: false) == [[1.0, 3.0], [-2.0, 0.0]])
 }
 
 private func verifyElementwiseArithmetic<T: TensorDenseTestImplementation>(_ type: T.Type) {


### PR DESCRIPTION
## Changes
- Add scalar, vector, and matrix extraction helpers for dense BLAS tensors.
- Add scalar, vector, and matrix extraction helpers for dense reference tensors.
- Add parameterized tests for lower tensor extraction.

Closes #65