### PR TITLE
Reference linear solver

### DIFF
--- a/Sources/LinearSolvers/DenseLinearSolvers.swift
+++ b/Sources/LinearSolvers/DenseLinearSolvers.swift
@@ -4,7 +4,48 @@ import AccelerateWrapper
 import OpenBLASWrapper
 import Tensors
 
+public typealias DenseLinearSolver<M: PluMatrix, V: PluVector> = (M, V) -> V where M.S == V.S
+
 public func solveLinearDense<M: PluMatrix, V: PluVector>(_ A: M, _ b: V, blasImplementation: BLAS = .default) -> V {
+    solveLinearDenseBLAS(A, b, blasImplementation: blasImplementation)
+}
+
+public func solveLinearDenseReference<M: PluMatrix, V: PluVector>(_ A: M, _ b: V) -> V where M.S == V.S {
+    precondition(A.rows == A.columns, "A must be square")
+    precondition(A.columns == b.size, "Number of columns in A must equal size of b")
+    let n = b.size
+    precondition(n > 0, "Linear systems must be non-empty")
+    var matrix = A.toArray()
+    var rhs = b.toArray()
+    for pivot in 0..<n {
+        let pivotRow = rowWithLargestPivot(matrix, column: pivot)
+        precondition(matrix[pivotRow][pivot].magnitude > .zero, "A must be non-singular")
+        if pivotRow != pivot {
+            matrix.swapAt(pivot, pivotRow)
+            rhs.swapAt(pivot, pivotRow)
+        }
+        for row in (pivot + 1)..<n {
+            let factor = matrix[row][pivot] / matrix[pivot][pivot]
+            matrix[row][pivot] = .zero
+            for column in (pivot + 1)..<n {
+                matrix[row][column] -= factor * matrix[pivot][column]
+            }
+            rhs[row] -= factor * rhs[pivot]
+        }
+    }
+    var x = Array(repeating: V.S.zero, count: n)
+    for row in stride(from: n - 1, through: 0, by: -1) {
+        var value = rhs[row]
+        for column in (row + 1)..<n {
+            value -= matrix[row][column] * x[column]
+        }
+        x[row] = value / matrix[row][row]
+    }
+    return V(x)
+}
+
+public func solveLinearDenseBLAS<M: PluMatrix, V: PluVector>(_ A: M, _ b: V, blasImplementation: BLAS = .default) -> V {
+    precondition(A.rows == A.columns, "A must be square")
     precondition(A.columns == b.size, "Number of columns in A must equal size of b")
     let n = b.size
     var x: [V.S]
@@ -44,4 +85,17 @@ public func solveLinearDense<M: PluMatrix, V: PluVector>(_ A: M, _ b: V, blasImp
     }
 
     return V(x)
+}
+
+private func rowWithLargestPivot<S: PluScalar>(_ matrix: [[S]], column: Int) -> Int {
+    var row = column
+    var pivot = matrix[column][column].magnitude
+    for candidate in (column + 1)..<matrix.count {
+        let magnitude = matrix[candidate][column].magnitude
+        if magnitude > pivot {
+            row = candidate
+            pivot = magnitude
+        }
+    }
+    return row
 }

--- a/Tests/LinearSolversTests/DenseLinearSolverTests.swift
+++ b/Tests/LinearSolversTests/DenseLinearSolverTests.swift
@@ -18,8 +18,16 @@ import Tensors
     #expect(v_actual.isApproximatelyEqual(to: v_expected))
 }
 
-func solveLinearDense_correctness_smallMatrices<MatrixType: PluMatrix>(matrixType: MatrixType.Type)
-        where MatrixType.S == Double {
+@Test func solveLinearDenseReference_exampleUsage() throws {
+    let A = MatrixDenseReference([[2.0, -1, 1], [1, 2, -1], [1, 1, -4]])
+    let b = VectorDenseReference([3.0, 2, -9])
+    let actual = solveLinearDenseReference(A, b)
+    let expected = VectorDenseReference([1.0, 2, 3])
+
+    #expect(actual.isApproximatelyEqual(to: expected))
+}
+
+func solveLinearDense_correctness_smallMatrices<MatrixType: PluMatrix>(matrixType: MatrixType.Type) where MatrixType.S == Double {
     let sizes = [2, 3, 10]
     for n in sizes {
         let A: MatrixType = makeMatrix(size: n)
@@ -31,8 +39,23 @@ func solveLinearDense_correctness_smallMatrices<MatrixType: PluMatrix>(matrixTyp
 }
 
 @Test func solveLinearDense_correctness_smallMatrices_reference() {
-    srand48(42)
-    solveLinearDense_correctness_smallMatrices(matrixType: MatrixDenseReference<Double>.self)
+    let A2 = MatrixDenseReference([[2.0, 1.0], [1.0, -1.0]])
+    let b2 = VectorDenseReference([4.0, -1.0])
+    let x2 = VectorDenseReference([1.0, 2.0])
+    let A3 = MatrixDenseReference([[2.0, -1, 1], [1, 2, -1], [1, 1, -4]])
+    let b3 = VectorDenseReference([3.0, 2, -9])
+    let x3 = VectorDenseReference([1.0, 2, 3])
+
+    #expect(solveLinearDenseReference(A2, b2).isApproximatelyEqual(to: x2))
+    #expect(solveLinearDenseReference(A3, b3).isApproximatelyEqual(to: x3))
+}
+
+@Test func solveLinearDenseReference_pivotsRows() {
+    let A = MatrixDenseReference([[0.0, 2.0], [1.0, 1.0]])
+    let b = VectorDenseReference([-2.0, 2.0])
+    let expected = VectorDenseReference([3.0, -1.0])
+
+    #expect(solveLinearDenseReference(A, b).isApproximatelyEqual(to: expected))
 }
 
 @Test func solveLinearDense_correctness_smallMatrices_BLAS() {
@@ -55,8 +78,17 @@ func solveLinearDense_correctness_smallMatrices<MatrixType: PluMatrix>(matrixTyp
     #endif
 }
 
-func solveLinearDense_correctness_largeMatrices<MatrixType: PluMatrix>(matrixType: MatrixType.Type)
-        where MatrixType.S == Double {
+@Test func solveLinearDenseReference_complex() {
+    let A = MatrixDenseReference<ComplexDouble>([[ComplexDouble(1.0, 0.0), ComplexDouble(0.0, 1.0)],
+                                                 [ComplexDouble(2.0, -1.0), ComplexDouble(1.0, 1.0)]])
+    let b = VectorDenseReference<ComplexDouble>([ComplexDouble(2.0, 3.0), ComplexDouble(6.0, 2.0)])
+    let expected = VectorDenseReference<ComplexDouble>([ComplexDouble(1.0, 1.0), ComplexDouble(2.0, -1.0)])
+    let actual = solveLinearDenseReference(A, b)
+
+    #expect(actual.isApproximatelyEqual(to: expected, relativeTolerance: 1e-12))
+}
+
+func solveLinearDenseBLAS_correctness_largeMatrices() {
     let sizes = [100, 500]
     for n in sizes {
         let A: MatrixDenseBLAS<Double> = makeMatrix(size: n)
@@ -67,14 +99,9 @@ func solveLinearDense_correctness_largeMatrices<MatrixType: PluMatrix>(matrixTyp
     }
 }
 
-@Test func solveLinearDense_correctness_largeMatrices_reference() {
-    srand48(42)
-    solveLinearDense_correctness_largeMatrices(matrixType: MatrixDenseReference<Double>.self)
-}
-
 @Test func solveLinearDense_correctness_largeMatrices_BLAS() {
     srand48(42)
-    solveLinearDense_correctness_largeMatrices(matrixType: MatrixDenseBLAS<Double>.self)
+    solveLinearDenseBLAS_correctness_largeMatrices()
 }
 
 func randomNumber() -> Double {


### PR DESCRIPTION
## Changes
- Add an explicit reference dense linear solver using Gaussian elimination with partial pivoting.
- Keep the default dense solver routed through the BLAS/LAPACK implementation.
- Add a shared dense solver function typealias.
- Add small reference solver tests for real, complex, and pivoting cases.

Closes #67