### PR TITLE
Benchmark linear solvers

### DIFF
--- a/Benchmarks/PythonNumPy/numpy_benchmarks.py
+++ b/Benchmarks/PythonNumPy/numpy_benchmarks.py
@@ -137,6 +137,19 @@ def benchmark_matrices(samples):
     print_result("inverse", "96x96", measure(3, 1, lambda: ends_2d(np.linalg.inv(det))))
 
 
+def benchmark_linear_solvers(samples):
+    print("Linear Solver")
+    small = invertible_matrix_values(16)
+    medium = invertible_matrix_values(64)
+    large = invertible_matrix_values(256)
+    small_b = vector_values(16)
+    medium_b = vector_values(64)
+    large_b = vector_values(256)
+    print_result("solve", "16x16", measure(samples, 1, lambda: ends_1d(np.linalg.solve(small, small_b))))
+    print_result("solve", "64x64", measure(3, 1, lambda: ends_1d(np.linalg.solve(medium, medium_b))))
+    print_result("solve", "256x256", measure(3, 1, lambda: ends_1d(np.linalg.solve(large, large_b))))
+
+
 def benchmark_tensors(samples):
     print("Tensor")
     add = tensor_values((40, 40, 10))
@@ -233,6 +246,7 @@ def main():
     print("")
     benchmark_vectors(args.samples)
     benchmark_matrices(args.samples)
+    benchmark_linear_solvers(args.samples)
     benchmark_tensors(args.samples)
     benchmark_float_scalars(args.samples)
     benchmark_complex_float_scalars(args.samples)

--- a/Sources/PlumeriaBenchmarks/main.swift
+++ b/Sources/PlumeriaBenchmarks/main.swift
@@ -367,6 +367,51 @@ func benchmarkMatrices() -> Double {
     return checksum
 }
 
+func benchmarkLinearSolvers() -> Double {
+    print("Linear Solver")
+    let smallRows = invertibleMatrixRows(size: 16)
+    let mediumRows = invertibleMatrixRows(size: 64)
+    let largeRows = invertibleMatrixRows(size: 256)
+    let smallB = vectorValues(count: 16)
+    let mediumB = vectorValues(count: 64)
+    let largeB = vectorValues(count: 256)
+    let referenceSmallA = MatrixDenseReference(smallRows)
+    let referenceMediumA = MatrixDenseReference(mediumRows)
+    let referenceLargeA = MatrixDenseReference(largeRows)
+    let blasSmallA = MatrixDenseBLAS(smallRows)
+    let blasMediumA = MatrixDenseBLAS(mediumRows)
+    let blasLargeA = MatrixDenseBLAS(largeRows)
+    let smallReferenceB = VectorDenseReference(smallB)
+    let mediumReferenceB = VectorDenseReference(mediumB)
+    let largeReferenceB = VectorDenseReference(largeB)
+    let smallBLASB = VectorDenseBLAS(smallB)
+    let mediumBLASB = VectorDenseBLAS(mediumB)
+    let largeBLASB = VectorDenseBLAS(largeB)
+    var checksum = 0.0
+    checksum += compareBenchmark("solve", "16x16", reference: {
+        let result = solveLinearDenseReference(referenceSmallA, smallReferenceB)
+        return result[0] + result[result.size - 1]
+    }, blas: {
+        let result = solveLinearDenseBLAS(blasSmallA, smallBLASB)
+        return result[0] + result[result.size - 1]
+    })
+    checksum += compareBenchmark("solve", "64x64", samples: 3, reference: {
+        let result = solveLinearDenseReference(referenceMediumA, mediumReferenceB)
+        return result[0] + result[result.size - 1]
+    }, blas: {
+        let result = solveLinearDenseBLAS(blasMediumA, mediumBLASB)
+        return result[0] + result[result.size - 1]
+    })
+    checksum += compareBenchmark("solve", "256x256", samples: 3, reference: {
+        let result = solveLinearDenseReference(referenceLargeA, largeReferenceB)
+        return result[0] + result[result.size - 1]
+    }, blas: {
+        let result = solveLinearDenseBLAS(blasLargeA, largeBLASB)
+        return result[0] + result[result.size - 1]
+    })
+    return checksum
+}
+
 func benchmarkTensors() -> Double {
     print("Tensor")
     var referenceAdd = TensorDenseReference<Double>(shape: [40, 40, 10], initialValue: 0.0)
@@ -731,5 +776,5 @@ print("Swift: \(swiftVersion)")
 print("Platform: \(platform)")
 print("")
 let blackHole = benchmarkVectors() + benchmarkMatrices() + benchmarkTensors()
-    + benchmarkFloatScalars() + benchmarkComplexFloatScalars() + benchmarkAccelerateVsOpenBLAS()
+    + benchmarkLinearSolvers() + benchmarkFloatScalars() + benchmarkComplexFloatScalars() + benchmarkAccelerateVsOpenBLAS()
 writeBenchmarkResultToNullDevice(blackHole)


### PR DESCRIPTION
## Changes
- Add PluMath dense linear solver benchmarks.
- Add matching NumPy dense linear solver benchmarks.
- Include reference-vs-BLAS and PluMath-vs-NumPy solve sizes.

Closes #69