### PR TITLE
Normalize lazy assignment terms

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -1,0 +1,102 @@
+# Benchmarks
+
+All times are medians in milliseconds from release-mode runs on one Apple Silicon machine.
+
+## Commands
+
+```sh
+swift run -c release PlumeriaBenchmarks
+uv run --with numpy python Benchmarks/PythonNumPy/numpy_benchmarks.py
+```
+
+## Environment
+
+- Swift: Apple Swift 6.3.2
+- Python: 3.12.11
+- NumPy: 2.4.6
+- Platform: M1 iMac, 8 cores, macOS 26.5
+
+## PluMath Reference vs. BLAS
+
+| Operation | Reference | BLAS/LAPACK | Reference/BLAS |
+| --- | ---: | ---: | ---: |
+| vector add 10,000 | 1.5214 | **0.0026** | 578.2098 |
+| vector scale 100,000 | 14.2040 | **0.0194** | 733.7443 |
+| vector magnitude 100,000 | 13.5820 | **0.0164** | 826.7003 |
+| matrix add 256x256 | 20.0685 | **0.0116** | 1730.0438 |
+| matrix add 1,024x1,024 | 327.1950 | **0.1868** | 1751.6634 |
+| matrix-vector 384x384 | 22.1599 | **0.0189** | 1174.0331 |
+| matrix-vector 1,536x1,536 | 360.2930 | **0.5257** | 685.4015 |
+| matrix-matrix 128x128 | 147.4689 | **0.0169** | 8717.7155 |
+| determinant 96x96 | 44.2640 | **0.0279** | 1587.9447 |
+| inverse 96x96 | 250.2594 | **0.0652** | 3837.8637 |
+| linear solve 16x16 | 0.1113 | **0.0030** | 36.6107 |
+| linear solve 64x64 | 6.0189 | **0.0205** | 293.0176 |
+| linear solve 256x256 | 370.4053 | **0.2665** | 1390.1078 |
+| tensor add 40x40x10 | 26.2750 | **0.0034** | 7658.8653 |
+| tensor contraction 16x24x16,16x16 | 21.5922 | **0.0071** | 3048.0250 |
+| tensor contraction 32x32x32,32x32 | 152.7592 | **0.0305** | 5015.4051 |
+
+## PluMath BLAS vs. NumPy
+
+| Operation | PluMath | NumPy |
+| --- | ---: | ---: |
+| vector add 10,000 | 0.0026 | **0.0019** |
+| vector scale 100,000 | 0.0194 | **0.0178** |
+| vector magnitude 100,000 | **0.0164** | 0.0169 |
+| matrix add 256x256 | **0.0116** | 0.0122 |
+| matrix add 1,024x1,024 | **0.1868** | 0.2036 |
+| matrix-vector 384x384 | 0.0189 | **0.0111** |
+| matrix-vector 1,536x1,536 | 0.5257 | **0.5244** |
+| matrix-matrix 128x128 | **0.0169** | 0.0170 |
+| determinant 96x96 | **0.0279** | 0.0315 |
+| inverse 96x96 | 0.0652 | **0.0613** |
+| linear solve 16x16 | **0.0030** | 0.0059 |
+| linear solve 64x64 | **0.0205** | 0.0226 |
+| linear solve 256x256 | 0.2665 | **0.2144** |
+| tensor add 40x40x10 | **0.0034** | 0.0035 |
+| tensor contraction 16x24x16,16x16 | **0.0071** | 0.0366 |
+| tensor contraction 32x32x32,32x32 | **0.0305** | 0.2932 |
+
+## Float and ComplexFloat
+
+| Operation | Double | Float |
+| --- | ---: | ---: |
+| vector add 100,000 | 0.0181 | **0.0101** |
+| magnitude 100,000 | 0.0161 | **0.0033** |
+| matrix-vector 384x384 | 0.0190 | **0.0046** |
+| matrix-matrix 128x128 | 0.0169 | **0.0058** |
+| tensor contraction 16x24x16,16x16 | 0.0065 | **0.0052** |
+
+| Operation | ComplexDouble | ComplexFloat |
+| --- | ---: | ---: |
+| vector add 100,000 | 0.0352 | **0.0182** |
+| magnitude 100,000 | 0.0322 | **0.0065** |
+| matrix-vector 384x384 | 0.1108 | **0.0167** |
+| matrix-matrix 128x128 | 0.0750 | **0.0232** |
+| tensor contraction 16x24x16,16x16 | 0.0128 | **0.0079** |
+
+## NumPy Lazy Expression Check
+
+NumPy does not appear to algebraically simplify repeated array terms in expressions such as
+`D[1:-1, 1:-1] = A[1:-1, 1:-1] + B[1:-1, 1:-1] - B[1:-1, 1:-1]`. The expression costs more than
+`A + B` and much more than copying `A` into the slice.
+
+| Slice size | Copy `A` | `A + B` | `A + B - B` | `A + B - B` / Copy |
+| --- | ---: | ---: | ---: | ---: |
+| 254x254 | 0.0196 | 0.0642 | 0.0905 | 4.62 |
+| 510x510 | 0.0773 | 0.2335 | 0.3456 | 4.47 |
+| 1022x1022 | 0.3157 | 1.0649 | 1.4958 | 4.74 |
+| 2046x2046 | 2.2758 | 4.8255 | 7.2002 | 3.16 |
+
+## Notes
+
+- Benchmarks are not correctness tests and do not run with `swift test`.
+- Results depend on hardware, Swift version, NumPy version, BLAS implementation, and thermal state.
+- Reference implementations are intentionally naive and math-like.
+- BLAS/LAPACK implementations are meant to be fast and to support implementation comparisons.
+- NumPy uses Accelerate on this macOS machine. For 256x256 linear solves, NumPy improves from about
+  0.218 ms with C-order input to about 0.175 ms with Fortran-order input. PluMath is about
+  0.26-0.28 ms after concrete dense solve overloads. A forced matrix/RHS copy costs only about
+  0.035 ms, and direct standalone Swift calls to `dgesv_` were slower than PluMath, so the remaining
+  gap appears to be in the exact LAPACK interface path rather than generic dispatch.

--- a/Sources/LinearSolvers/DenseLinearSolvers.swift
+++ b/Sources/LinearSolvers/DenseLinearSolvers.swift
@@ -31,28 +31,28 @@ public func solveLinearDenseReference<M: PluMatrix, V: PluVector>(_ A: M, _ b: V
     var matrix = A.toArray()
     var rhs = b.toArray()
     for pivot in 0..<n {
-        let pivotRow = rowWithLargestPivot(matrix, column: pivot)
+        let pivotRow = rowWithLargestPivot(matrix, j: pivot)
         precondition(matrix[pivotRow][pivot].magnitude > .zero, "A must be non-singular")
         if pivotRow != pivot {
             matrix.swapAt(pivot, pivotRow)
             rhs.swapAt(pivot, pivotRow)
         }
-        for row in (pivot + 1)..<n {
-            let factor = matrix[row][pivot] / matrix[pivot][pivot]
-            matrix[row][pivot] = .zero
-            for column in (pivot + 1)..<n {
-                matrix[row][column] -= factor * matrix[pivot][column]
+        for i in (pivot + 1)..<n {
+            let factor = matrix[i][pivot] / matrix[pivot][pivot]
+            matrix[i][pivot] = .zero
+            for j in (pivot + 1)..<n {
+                matrix[i][j] -= factor * matrix[pivot][j]
             }
-            rhs[row] -= factor * rhs[pivot]
+            rhs[i] -= factor * rhs[pivot]
         }
     }
     var x = Array(repeating: V.S.zero, count: n)
-    for row in stride(from: n - 1, through: 0, by: -1) {
-        var value = rhs[row]
-        for column in (row + 1)..<n {
-            value -= matrix[row][column] * x[column]
+    for i in stride(from: n - 1, through: 0, by: -1) {
+        var value = rhs[i]
+        for j in (i + 1)..<n {
+            value -= matrix[i][j] * x[j]
         }
-        x[row] = value / matrix[row][row]
+        x[i] = value / matrix[i][i]
     }
     return V(x)
 }
@@ -146,15 +146,15 @@ private func solveComplexDoubleLinearSystem(
     }
 }
 
-private func rowWithLargestPivot<S: PluScalar>(_ matrix: [[S]], column: Int) -> Int {
-    var row = column
-    var pivot = matrix[column][column].magnitude
-    for candidate in (column + 1)..<matrix.count {
-        let magnitude = matrix[candidate][column].magnitude
+private func rowWithLargestPivot<S: PluScalar>(_ matrix: [[S]], j: Int) -> Int {
+    var i = j
+    var pivot = matrix[j][j].magnitude
+    for candidate in (j + 1)..<matrix.count {
+        let magnitude = matrix[candidate][j].magnitude
         if magnitude > pivot {
-            row = candidate
+            i = candidate
             pivot = magnitude
         }
     }
-    return row
+    return i
 }

--- a/Sources/LinearSolvers/DenseLinearSolvers.swift
+++ b/Sources/LinearSolvers/DenseLinearSolvers.swift
@@ -127,11 +127,11 @@ public func solveLinearDenseBLAS<M: PluMatrix, V: PluVector>(_ A: M, _ b: V, bla
         #if canImport(Accelerate)
         case .accelerate:
             let _ = AccelerateOperations.cgesv(Int32(n), &AArray, &bArray)
-            x = BLASComplexStorage.complexValues(bArray) as! [V.S]
+            x = BLASComplexStorage.toComplex(bArray) as! [V.S]
         #endif
         case .openBLAS:
             let _ = OpenBLASOperations.cgesv(Int32(n), &AArray, &bArray)
-            x = BLASComplexStorage.complexValues(bArray) as! [V.S]
+            x = BLASComplexStorage.toComplex(bArray) as! [V.S]
         }
 
     default:
@@ -186,7 +186,7 @@ public func solveLinearDenseBLAS(
     var rhs = BLASComplexStorage.interleaved(b.elements)
     let info = solveComplexFloatLinearSystem(Int32(b.size), &matrix, &rhs, blasImplementation: blasImplementation)
     precondition(info == 0, "LAPACK linear solve failed with info \(info)")
-    return VectorDenseBLAS(BLASComplexStorage.complexValues(rhs))
+    return VectorDenseBLAS(BLASComplexStorage.toComplex(rhs))
 }
 
 private func solveFloatLinearSystem(

--- a/Sources/LinearSolvers/DenseLinearSolvers.swift
+++ b/Sources/LinearSolvers/DenseLinearSolvers.swift
@@ -86,11 +86,11 @@ public func solveLinearDenseBLAS<M: PluMatrix, V: PluVector>(_ A: M, _ b: V, bla
         #if canImport(Accelerate)
         case .accelerate:
             let _ = AccelerateOperations.zgesv(Int32(n), &AArray, &bArray)
-            x = BLASComplexStorage.complexValues(bArray) as! [V.S]
+            x = BLASComplexStorage.toComplex(bArray) as! [V.S]
         #endif
         case .openBLAS:
             let _ = OpenBLASOperations.zgesv(Int32(n), &AArray, &bArray)
-            x = BLASComplexStorage.complexValues(bArray) as! [V.S]
+            x = BLASComplexStorage.toComplex(bArray) as! [V.S]
         }
 
     default:
@@ -121,7 +121,7 @@ public func solveLinearDenseBLAS(
     var rhs = BLASComplexStorage.interleaved(b.elements)
     let info = solveComplexDoubleLinearSystem(Int32(b.size), &matrix, &rhs, blasImplementation: blasImplementation)
     precondition(info == 0, "LAPACK linear solve failed with info \(info)")
-    return VectorDenseBLAS(BLASComplexStorage.complexValues(rhs))
+    return VectorDenseBLAS(BLASComplexStorage.toComplex(rhs))
 }
 
 private func solveDoubleLinearSystem(

--- a/Sources/PlumeriaBenchmarks/main.swift
+++ b/Sources/PlumeriaBenchmarks/main.swift
@@ -185,11 +185,11 @@ func vectorComplexFloatValues(count: Int) -> [ComplexFloat] {
 func matrixRows(rows: Int, columns: Int) -> [[Double]] {
     var values: [[Double]] = []
     values.reserveCapacity(rows)
-    for row in 0..<rows {
+    for i in 0..<rows {
         var rowValues: [Double] = []
         rowValues.reserveCapacity(columns)
-        for column in 0..<columns {
-            rowValues.append(Double(((row * 31 + column * 17) % 101) - 50) / 11.0)
+        for j in 0..<columns {
+            rowValues.append(Double(((i * 31 + j * 17) % 101) - 50) / 11.0)
         }
         values.append(rowValues)
     }
@@ -197,10 +197,10 @@ func matrixRows(rows: Int, columns: Int) -> [[Double]] {
 }
 
 func invertibleMatrixRows(size: Int) -> [[Double]] {
-    (0..<size).map { row in
-        (0..<size).map { column in
-            let value = Double(((row * 31 + column * 17) % 101) - 50) / 11.0
-            return row == column ? value + Double(size) : value
+    (0..<size).map { i in
+        (0..<size).map { j in
+            let value = Double(((i * 31 + j * 17) % 101) - 50) / 11.0
+            return i == j ? value + Double(size) : value
         }
     }
 }
@@ -210,40 +210,40 @@ func matrixFloatRows(rows: Int, columns: Int) -> [[Float]] {
 }
 
 func matrixComplexRows(rows: Int, columns: Int) -> [[ComplexDouble]] {
-    matrixRows(rows: rows, columns: columns).map { row in row.map { ComplexDouble($0, -$0 / 3.0) } }
+    matrixRows(rows: rows, columns: columns).map { $0.map { ComplexDouble($0, -$0 / 3.0) } }
 }
 
 func matrixComplexFloatRows(rows: Int, columns: Int) -> [[ComplexFloat]] {
-    matrixRows(rows: rows, columns: columns).map { row in row.map { ComplexFloat(Float($0), Float(-$0 / 3.0)) } }
+    matrixRows(rows: rows, columns: columns).map { $0.map { ComplexFloat(Float($0), Float(-$0 / 3.0)) } }
 }
 
 func fillTensor<T: TensorMultiplication>(_ tensor: inout T) where T.S == Double {
-    for index in indexCombinations(for: tensor.shape) {
-        let weighted = index.enumerated().reduce(0) { $0 + ($1.offset + 1) * ($1.element + 1) }
-        tensor[index] = Double((weighted % 29) - 14) / 5.0
+    for i in indexCombinations(for: tensor.shape) {
+        let weighted = i.enumerated().reduce(0) { $0 + ($1.offset + 1) * ($1.element + 1) }
+        tensor[i] = Double((weighted % 29) - 14) / 5.0
     }
 }
 
 func fillFloatTensor<T: TensorMultiplication>(_ tensor: inout T) where T.S == Float {
-    for index in indexCombinations(for: tensor.shape) {
-        let weighted = index.enumerated().reduce(0) { $0 + ($1.offset + 1) * ($1.element + 1) }
-        tensor[index] = Float((weighted % 29) - 14) / 5.0
+    for i in indexCombinations(for: tensor.shape) {
+        let weighted = i.enumerated().reduce(0) { $0 + ($1.offset + 1) * ($1.element + 1) }
+        tensor[i] = Float((weighted % 29) - 14) / 5.0
     }
 }
 
 func fillComplexTensor<T: TensorMultiplication>(_ tensor: inout T) where T.S == ComplexDouble {
-    for index in indexCombinations(for: tensor.shape) {
-        let weighted = index.enumerated().reduce(0) { $0 + ($1.offset + 1) * ($1.element + 1) }
+    for i in indexCombinations(for: tensor.shape) {
+        let weighted = i.enumerated().reduce(0) { $0 + ($1.offset + 1) * ($1.element + 1) }
         let value = Double((weighted % 29) - 14) / 5.0
-        tensor[index] = ComplexDouble(value, -value / 2.0)
+        tensor[i] = ComplexDouble(value, -value / 2.0)
     }
 }
 
 func fillComplexFloatTensor<T: TensorMultiplication>(_ tensor: inout T) where T.S == ComplexFloat {
-    for index in indexCombinations(for: tensor.shape) {
-        let weighted = index.enumerated().reduce(0) { $0 + ($1.offset + 1) * ($1.element + 1) }
+    for i in indexCombinations(for: tensor.shape) {
+        let weighted = i.enumerated().reduce(0) { $0 + ($1.offset + 1) * ($1.element + 1) }
         let value = Float((weighted % 29) - 14) / 5.0
-        tensor[index] = ComplexFloat(value, -value / 2.0)
+        tensor[i] = ComplexFloat(value, -value / 2.0)
     }
 }
 
@@ -253,9 +253,9 @@ func indexCombinations(for shape: [Int]) -> [[Int]] {
     return (0..<shape.reduce(1, *)).map { flatIndex in
         var remaining = flatIndex
         return shape.map { dimension in
-            let index = remaining % dimension
+            let i = remaining % dimension
             remaining /= dimension
-            return index
+            return i
         }
     }
 }

--- a/Sources/Tensors/BLASComplexStorage.swift
+++ b/Sources/Tensors/BLASComplexStorage.swift
@@ -104,7 +104,7 @@ public enum BLASComplexStorage {
         return interleaved
     }
 
-    public static func complexValues<RealType: Real>(_ values: [RealType]) -> [Numerics.Complex<RealType>] {
+    public static func toComplex<RealType: Real>(_ values: [RealType]) -> [Numerics.Complex<RealType>] {
         var complex = Array(repeating: Numerics.Complex<RealType>.zero, count: values.count / 2)
         for index in 0..<complex.count { complex[index] = Numerics.Complex(values[2 * index], values[2 * index + 1]) }
         return complex

--- a/Sources/Tensors/BLASComplexStorage.swift
+++ b/Sources/Tensors/BLASComplexStorage.swift
@@ -46,7 +46,7 @@ public enum BLASComplexStorage {
                     let rawResult = UnsafeMutableRawBufferPointer(result)
                     let left = left.bindMemory(to: Double.self), right = right.bindMemory(to: Double.self)
                     let result = rawResult.bindMemory(to: Double.self)
-                    for index in 0..<result.count { result[index] = left[index] + right[index] }
+                    for i in 0..<result.count { result[i] = left[i] + right[i] }
                 }
             }
             initializedCount = left.count
@@ -60,7 +60,7 @@ public enum BLASComplexStorage {
                     let rawResult = UnsafeMutableRawBufferPointer(result)
                     let left = left.bindMemory(to: Float.self), right = right.bindMemory(to: Float.self)
                     let result = rawResult.bindMemory(to: Float.self)
-                    for index in 0..<result.count { result[index] = left[index] + right[index] }
+                    for i in 0..<result.count { result[i] = left[i] + right[i] }
                 }
             }
             initializedCount = left.count
@@ -74,7 +74,7 @@ public enum BLASComplexStorage {
                     let rawResult = UnsafeMutableRawBufferPointer(result)
                     let left = left.bindMemory(to: Double.self), right = right.bindMemory(to: Double.self)
                     let result = rawResult.bindMemory(to: Double.self)
-                    for index in 0..<result.count { result[index] = left[index] - right[index] }
+                    for i in 0..<result.count { result[i] = left[i] - right[i] }
                 }
             }
             initializedCount = left.count
@@ -88,7 +88,7 @@ public enum BLASComplexStorage {
                     let rawResult = UnsafeMutableRawBufferPointer(result)
                     let left = left.bindMemory(to: Float.self), right = right.bindMemory(to: Float.self)
                     let result = rawResult.bindMemory(to: Float.self)
-                    for index in 0..<result.count { result[index] = left[index] - right[index] }
+                    for i in 0..<result.count { result[i] = left[i] - right[i] }
                 }
             }
             initializedCount = left.count
@@ -97,16 +97,16 @@ public enum BLASComplexStorage {
 
     public static func interleaved<RealType: Real>(_ values: [Numerics.Complex<RealType>]) -> [RealType] {
         var interleaved = Array(repeating: RealType.zero, count: values.count * 2)
-        for index in 0..<values.count {
-            interleaved[2 * index] = values[index].real
-            interleaved[2 * index + 1] = values[index].imaginary
+        for i in 0..<values.count {
+            interleaved[2 * i] = values[i].real
+            interleaved[2 * i + 1] = values[i].imaginary
         }
         return interleaved
     }
 
     public static func toComplex<RealType: Real>(_ values: [RealType]) -> [Numerics.Complex<RealType>] {
         var complex = Array(repeating: Numerics.Complex<RealType>.zero, count: values.count / 2)
-        for index in 0..<complex.count { complex[index] = Numerics.Complex(values[2 * index], values[2 * index + 1]) }
+        for i in 0..<complex.count { complex[i] = Numerics.Complex(values[2 * i], values[2 * i + 1]) }
         return complex
     }
 

--- a/Sources/Tensors/Core/PluMatrix.swift
+++ b/Sources/Tensors/Core/PluMatrix.swift
@@ -46,11 +46,11 @@ extension PluMatrix {
             let rowRange = rows.sliceRange(dimensionSize: self.rows)
             let columnRange = columns.sliceRange(dimensionSize: self.columns)
             var result = Self(rows: rowRange.length, columns: columnRange.length, initialValue: .zero)
-            for row in 0..<rowRange.length {
-                for column in 0..<columnRange.length {
-                    let sourceRow = rowRange.start + row * rowRange.step
-                    let sourceColumn = columnRange.start + column * columnRange.step
-                    result[row, column] = self[sourceRow, sourceColumn]
+            for i in 0..<rowRange.length {
+                for j in 0..<columnRange.length {
+                    let sourceI = rowRange.start + i * rowRange.step
+                    let sourceJ = columnRange.start + j * columnRange.step
+                    result[i, j] = self[sourceI, sourceJ]
                 }
             }
             return result
@@ -63,11 +63,11 @@ extension PluMatrix {
             if let error {
                 preconditionFailure(error)
             }
-            for row in 0..<rowRange.length {
-                for column in 0..<columnRange.length {
-                    let destinationRow = rowRange.start + row * rowRange.step
-                    let destinationColumn = columnRange.start + column * columnRange.step
-                    self[destinationRow, destinationColumn] = newValue[row, column]
+            for i in 0..<rowRange.length {
+                for j in 0..<columnRange.length {
+                    let destinationI = rowRange.start + i * rowRange.step
+                    let destinationJ = columnRange.start + j * columnRange.step
+                    self[destinationI, destinationJ] = newValue[i, j]
                 }
             }
         }

--- a/Sources/Tensors/Core/PluScalar.swift
+++ b/Sources/Tensors/Core/PluScalar.swift
@@ -73,9 +73,11 @@ extension PluScalar {
     public func isClose(
         to other: Self,
         relativeTolerance: Magnitude = Magnitude.ulpOfOne.squareRoot(),
-        norm: (Self) -> Magnitude = { _ in .zero }
+        norm _: (Self) -> Magnitude = { _ in .zero }
     ) -> Bool {
-        isApproximatelyEqual(to: other, relativeTolerance: relativeTolerance)
+        let difference = (self - other).magnitude
+        if difference == .zero { return true }
+        return difference <= relativeTolerance * max(magnitude, other.magnitude)
     }
 
     public func round() -> Self {

--- a/Sources/Tensors/Core/PluScalar.swift
+++ b/Sources/Tensors/Core/PluScalar.swift
@@ -70,6 +70,14 @@ public func / (left: Float, right: ComplexFloat) -> ComplexFloat { ComplexFloat(
 public func / (left: ComplexFloat, right: Float) -> ComplexFloat { left / ComplexFloat(right, 0.0) }
 
 extension PluScalar {
+    public func isClose(
+        to other: Self,
+        relativeTolerance: Magnitude = Magnitude.ulpOfOne.squareRoot(),
+        norm: (Self) -> Magnitude = { _ in .zero }
+    ) -> Bool {
+        isApproximatelyEqual(to: other, relativeTolerance: relativeTolerance)
+    }
+
     public func round() -> Self {
         switch Self.self {
         case is Float.Type, is ComplexFloat.Type:

--- a/Sources/Tensors/Core/PluVector.swift
+++ b/Sources/Tensors/Core/PluVector.swift
@@ -1,6 +1,6 @@
 public protocol PluVector: PluTensor, TensorStructure where S: PluScalar {
     var size: Int { get }
-    subscript(index: Int) -> S { get set }
+    subscript(i: Int) -> S { get set }
 
     init(_ elements: [S])
 
@@ -21,9 +21,9 @@ extension PluVector {
         set { self[TensorSliceIndex.range(range)] = newValue }
     }
 
-    public subscript(index: TensorSliceIndex) -> Self {
+    public subscript(i: TensorSliceIndex) -> Self {
         get {
-            let range = index.sliceRange(dimensionSize: size)
+            let range = i.sliceRange(dimensionSize: size)
             var result = Self(Array(repeating: .zero, count: range.length))
             for position in 0..<range.length {
                 result[position] = self[range.start + position * range.step]
@@ -31,7 +31,7 @@ extension PluVector {
             return result
         }
         set {
-            let range = index.sliceRange(dimensionSize: size)
+            let range = i.sliceRange(dimensionSize: size)
             let error = sliceAssignmentShapeError(destination: [range.length], replacement: newValue.shape)
             if let error {
                 preconditionFailure(error)
@@ -47,8 +47,8 @@ extension PluVector {
     public func dot<V: PluVector>(_ other: V) -> S where V.S == S {
         precondition(size == other.size, "Vector sizes must match")
         var sum = S.zero
-        for index in 0..<size {
-            sum += self[index] * other[index]
+        for i in 0..<size {
+            sum += self[i] * other[i]
         }
         return sum
     }

--- a/Sources/Tensors/Matrix/LazyMatrix.swift
+++ b/Sources/Tensors/Matrix/LazyMatrix.swift
@@ -36,21 +36,58 @@ struct LazyMatrix<S: PluScalar> {
     }
 
     func materializedElements(rows: Int, columns: Int) -> [S] {
+        let terms = Self.normalized(terms)
         var elements = Array(repeating: S.zero, count: rows * columns)
         for column in 0..<columns {
             let resultColumn = column * rows
-            for row in 0..<rows { elements[resultColumn + row] = value(row: row, column: column) }
+            for row in 0..<rows { elements[resultColumn + row] = value(row: row, column: column, terms: terms) }
         }
         return elements
     }
 
     func assign(to destination: inout TensorFlatView<S>) {
+        assign(terms: Self.normalized(terms), to: &destination)
+    }
+
+    private func assign(terms: [Term], to destination: inout TensorFlatView<S>) {
         for column in 0..<destination.shape[1] {
             let destinationColumn = destination.offset + column * destination.strides[1]
             for row in 0..<destination.shape[0] {
-                destination.storage[destinationColumn + row * destination.strides[0]] = value(row: row, column: column)
+                var result = S.zero
+                for term in terms {
+                    let index = term.view.offset + row * term.view.strides[0] + column * term.view.strides[1]
+                    result += term.coefficient * term.view.storage.elements[index]
+                }
+                destination.storage[destinationColumn + row * destination.strides[0]] = result
             }
         }
+    }
+
+    static func normalized(_ terms: [Term]) -> [Term] {
+        var normalized: [Term] = []
+        for term in terms {
+            if term.coefficient == S.zero { continue }
+            if let index = normalized.firstIndex(where: { $0.view.sameStorageRegion(as: term.view) }) {
+                let coefficient = normalized[index].coefficient + term.coefficient
+                if coefficient == S.zero {
+                    normalized.remove(at: index)
+                } else {
+                    normalized[index] = Term(coefficient: coefficient, view: normalized[index].view)
+                }
+            } else {
+                normalized.append(term)
+            }
+        }
+        return normalized
+    }
+
+    private func value(row: Int, column: Int, terms: [Term]) -> S {
+        var result = S.zero
+        for term in terms {
+            let index = term.view.offset + row * term.view.strides[0] + column * term.view.strides[1]
+            result += term.coefficient * term.view.storage.elements[index]
+        }
+        return result
     }
 }
 
@@ -60,6 +97,15 @@ extension LazyMatrix where S == Double {
             assignSevenTerms(to: &destination)
             return
         }
+        let terms = Self.normalized(terms)
+        if destination.strides[0] == 1 && terms.allSatisfy({ $0.view.strides[0] == 1 }) {
+            assignRowContiguousTerms(terms, to: &destination)
+            return
+        }
+        assignGenericTerms(terms, to: &destination)
+    }
+
+    private func assignGenericTerms(_ terms: [Term], to destination: inout TensorFlatView<Double>) {
         let termData = terms.map {
             (
                 coefficient: $0.coefficient, elements: $0.view.storage.elements, offset: $0.view.offset,
@@ -75,6 +121,56 @@ extension LazyMatrix where S == Double {
                     result += term.coefficient * term.elements[index]
                 }
                 destination.storage.elements[destinationColumn + row * destination.strides[0]] = result
+            }
+        }
+    }
+
+    private func assignRowContiguousTerms(_ terms: [Term], to destination: inout TensorFlatView<Double>) {
+        if terms.allSatisfy({ $0.view.storage !== destination.storage }) {
+            assignDistinctRowContiguousTerms(terms, to: &destination)
+            return
+        }
+        let termData = terms.map {
+            (
+                coefficient: $0.coefficient, elements: $0.view.storage.elements, offset: $0.view.offset,
+                columnStride: $0.view.strides[1]
+            )
+        }
+        for column in 0..<destination.shape[1] {
+            var d = destination.offset + column * destination.strides[1]
+            var indices = termData.map { $0.offset + column * $0.columnStride }
+            for _ in 0..<destination.shape[0] {
+                var result = 0.0
+                for termIndex in termData.indices {
+                    result += termData[termIndex].coefficient * termData[termIndex].elements[indices[termIndex]]
+                    indices[termIndex] += 1
+                }
+                destination.storage.elements[d] = result
+                d += 1
+            }
+        }
+    }
+
+    private func assignDistinctRowContiguousTerms(_ terms: [Term], to destination: inout TensorFlatView<Double>) {
+        let termData = terms.map {
+            (
+                coefficient: $0.coefficient, elements: $0.view.storage.elements, offset: $0.view.offset,
+                columnStride: $0.view.strides[1]
+            )
+        }
+        destination.storage.elements.withUnsafeMutableBufferPointer { destinationElements in
+            for column in 0..<destination.shape[1] {
+                var d = destination.offset + column * destination.strides[1]
+                var indices = termData.map { $0.offset + column * $0.columnStride }
+                for _ in 0..<destination.shape[0] {
+                    var result = 0.0
+                    for termIndex in termData.indices {
+                        result += termData[termIndex].coefficient * termData[termIndex].elements[indices[termIndex]]
+                        indices[termIndex] += 1
+                    }
+                    destinationElements[d] = result
+                    d += 1
+                }
             }
         }
     }

--- a/Sources/Tensors/Matrix/LazyMatrix.swift
+++ b/Sources/Tensors/Matrix/LazyMatrix.swift
@@ -26,11 +26,11 @@ struct LazyMatrix<S: PluScalar> {
         LazyMatrix(terms: terms.map { Term(coefficient: scalar * $0.coefficient, view: $0.view) })
     }
 
-    func value(row: Int, column: Int) -> S {
+    func value(i: Int, j: Int) -> S {
         var result = S.zero
         for term in terms {
-            let index = term.view.offset + row * term.view.strides[0] + column * term.view.strides[1]
-            result += term.coefficient * term.view.storage.elements[index]
+            let k = term.view.offset + i * term.view.strides[0] + j * term.view.strides[1]
+            result += term.coefficient * term.view.storage.elements[k]
         }
         return result
     }
@@ -38,9 +38,9 @@ struct LazyMatrix<S: PluScalar> {
     func materializedElements(rows: Int, columns: Int) -> [S] {
         let terms = Self.normalized(terms)
         var elements = Array(repeating: S.zero, count: rows * columns)
-        for column in 0..<columns {
-            let resultColumn = column * rows
-            for row in 0..<rows { elements[resultColumn + row] = value(row: row, column: column, terms: terms) }
+        for j in 0..<columns {
+            let resultColumn = j * rows
+            for i in 0..<rows { elements[resultColumn + i] = value(i: i, j: j, terms: terms) }
         }
         return elements
     }
@@ -50,15 +50,15 @@ struct LazyMatrix<S: PluScalar> {
     }
 
     private func assign(terms: [Term], to destination: inout TensorFlatView<S>) {
-        for column in 0..<destination.shape[1] {
-            let destinationColumn = destination.offset + column * destination.strides[1]
-            for row in 0..<destination.shape[0] {
+        for j in 0..<destination.shape[1] {
+            let destinationColumn = destination.offset + j * destination.strides[1]
+            for i in 0..<destination.shape[0] {
                 var result = S.zero
                 for term in terms {
-                    let index = term.view.offset + row * term.view.strides[0] + column * term.view.strides[1]
-                    result += term.coefficient * term.view.storage.elements[index]
+                    let k = term.view.offset + i * term.view.strides[0] + j * term.view.strides[1]
+                    result += term.coefficient * term.view.storage.elements[k]
                 }
-                destination.storage[destinationColumn + row * destination.strides[0]] = result
+                destination.storage[destinationColumn + i * destination.strides[0]] = result
             }
         }
     }
@@ -67,12 +67,12 @@ struct LazyMatrix<S: PluScalar> {
         var normalized: [Term] = []
         for term in terms {
             if term.coefficient == S.zero { continue }
-            if let index = normalized.firstIndex(where: { $0.view.sameStorageRegion(as: term.view) }) {
-                let coefficient = normalized[index].coefficient + term.coefficient
+            if let i = normalized.firstIndex(where: { $0.view.sameStorageRegion(as: term.view) }) {
+                let coefficient = normalized[i].coefficient + term.coefficient
                 if coefficient == S.zero {
-                    normalized.remove(at: index)
+                    normalized.remove(at: i)
                 } else {
-                    normalized[index] = Term(coefficient: coefficient, view: normalized[index].view)
+                    normalized[i] = Term(coefficient: coefficient, view: normalized[i].view)
                 }
             } else {
                 normalized.append(term)
@@ -81,11 +81,11 @@ struct LazyMatrix<S: PluScalar> {
         return normalized
     }
 
-    private func value(row: Int, column: Int, terms: [Term]) -> S {
+    private func value(i: Int, j: Int, terms: [Term]) -> S {
         var result = S.zero
         for term in terms {
-            let index = term.view.offset + row * term.view.strides[0] + column * term.view.strides[1]
-            result += term.coefficient * term.view.storage.elements[index]
+            let k = term.view.offset + i * term.view.strides[0] + j * term.view.strides[1]
+            result += term.coefficient * term.view.storage.elements[k]
         }
         return result
     }
@@ -112,15 +112,15 @@ extension LazyMatrix where S == Double {
                 rowStride: $0.view.strides[0], columnStride: $0.view.strides[1]
             )
         }
-        for column in 0..<destination.shape[1] {
-            let destinationColumn = destination.offset + column * destination.strides[1]
-            for row in 0..<destination.shape[0] {
+        for j in 0..<destination.shape[1] {
+            let destinationColumn = destination.offset + j * destination.strides[1]
+            for i in 0..<destination.shape[0] {
                 var result = 0.0
                 for term in termData {
-                    let index = term.offset + row * term.rowStride + column * term.columnStride
-                    result += term.coefficient * term.elements[index]
+                    let k = term.offset + i * term.rowStride + j * term.columnStride
+                    result += term.coefficient * term.elements[k]
                 }
-                destination.storage.elements[destinationColumn + row * destination.strides[0]] = result
+                destination.storage.elements[destinationColumn + i * destination.strides[0]] = result
             }
         }
     }
@@ -136,14 +136,14 @@ extension LazyMatrix where S == Double {
                 columnStride: $0.view.strides[1]
             )
         }
-        for column in 0..<destination.shape[1] {
-            var d = destination.offset + column * destination.strides[1]
-            var indices = termData.map { $0.offset + column * $0.columnStride }
+        for j in 0..<destination.shape[1] {
+            var d = destination.offset + j * destination.strides[1]
+            var indices = termData.map { $0.offset + j * $0.columnStride }
             for _ in 0..<destination.shape[0] {
                 var result = 0.0
-                for termIndex in termData.indices {
-                    result += termData[termIndex].coefficient * termData[termIndex].elements[indices[termIndex]]
-                    indices[termIndex] += 1
+                for k in termData.indices {
+                    result += termData[k].coefficient * termData[k].elements[indices[k]]
+                    indices[k] += 1
                 }
                 destination.storage.elements[d] = result
                 d += 1
@@ -159,14 +159,14 @@ extension LazyMatrix where S == Double {
             )
         }
         destination.storage.elements.withUnsafeMutableBufferPointer { destinationElements in
-            for column in 0..<destination.shape[1] {
-                var d = destination.offset + column * destination.strides[1]
-                var indices = termData.map { $0.offset + column * $0.columnStride }
+            for j in 0..<destination.shape[1] {
+                var d = destination.offset + j * destination.strides[1]
+                var indices = termData.map { $0.offset + j * $0.columnStride }
                 for _ in 0..<destination.shape[0] {
                     var result = 0.0
-                    for termIndex in termData.indices {
-                        result += termData[termIndex].coefficient * termData[termIndex].elements[indices[termIndex]]
-                        indices[termIndex] += 1
+                    for k in termData.indices {
+                        result += termData[k].coefficient * termData[k].elements[indices[k]]
+                        indices[k] += 1
                     }
                     destinationElements[d] = result
                     d += 1
@@ -189,24 +189,24 @@ extension LazyMatrix where S == Double {
         let s0 = t0.view.strides[0], s1 = t1.view.strides[0], s2 = t2.view.strides[0], s3 = t3.view.strides[0]
         let s4 = t4.view.strides[0], s5 = t5.view.strides[0], s6 = t6.view.strides[0]
         let ds = destination.strides[0]
-        for column in 0..<destination.shape[1] {
-            let d = destination.offset + column * destination.strides[1]
-            let c0 = t0.view.offset + column * t0.view.strides[1]
-            let c1 = t1.view.offset + column * t1.view.strides[1]
-            let c2 = t2.view.offset + column * t2.view.strides[1]
-            let c3 = t3.view.offset + column * t3.view.strides[1]
-            let c4 = t4.view.offset + column * t4.view.strides[1]
-            let c5 = t5.view.offset + column * t5.view.strides[1]
-            let c6 = t6.view.offset + column * t6.view.strides[1]
-            for row in 0..<destination.shape[0] {
-                var result = a0 * e0[c0 + row * s0]
-                result += a1 * e1[c1 + row * s1]
-                result += a2 * e2[c2 + row * s2]
-                result += a3 * e3[c3 + row * s3]
-                result += a4 * e4[c4 + row * s4]
-                result += a5 * e5[c5 + row * s5]
-                result += a6 * e6[c6 + row * s6]
-                destination.storage.elements[d + row * ds] = result
+        for j in 0..<destination.shape[1] {
+            let d = destination.offset + j * destination.strides[1]
+            let c0 = t0.view.offset + j * t0.view.strides[1]
+            let c1 = t1.view.offset + j * t1.view.strides[1]
+            let c2 = t2.view.offset + j * t2.view.strides[1]
+            let c3 = t3.view.offset + j * t3.view.strides[1]
+            let c4 = t4.view.offset + j * t4.view.strides[1]
+            let c5 = t5.view.offset + j * t5.view.strides[1]
+            let c6 = t6.view.offset + j * t6.view.strides[1]
+            for i in 0..<destination.shape[0] {
+                var result = a0 * e0[c0 + i * s0]
+                result += a1 * e1[c1 + i * s1]
+                result += a2 * e2[c2 + i * s2]
+                result += a3 * e3[c3 + i * s3]
+                result += a4 * e4[c4 + i * s4]
+                result += a5 * e5[c5 + i * s5]
+                result += a6 * e6[c6 + i * s6]
+                destination.storage.elements[d + i * ds] = result
             }
         }
     }
@@ -222,15 +222,15 @@ extension LazyMatrix where S == Double {
         let e6 = t6.view.storage.elements
         let a0 = t0.coefficient, a1 = t1.coefficient, a2 = t2.coefficient, a3 = t3.coefficient
         let a4 = t4.coefficient, a5 = t5.coefficient, a6 = t6.coefficient
-        for column in 0..<destination.shape[1] {
-            var d = destination.offset + column * destination.strides[1]
-            var i0 = t0.view.offset + column * t0.view.strides[1]
-            var i1 = t1.view.offset + column * t1.view.strides[1]
-            var i2 = t2.view.offset + column * t2.view.strides[1]
-            var i3 = t3.view.offset + column * t3.view.strides[1]
-            var i4 = t4.view.offset + column * t4.view.strides[1]
-            var i5 = t5.view.offset + column * t5.view.strides[1]
-            var i6 = t6.view.offset + column * t6.view.strides[1]
+        for j in 0..<destination.shape[1] {
+            var d = destination.offset + j * destination.strides[1]
+            var i0 = t0.view.offset + j * t0.view.strides[1]
+            var i1 = t1.view.offset + j * t1.view.strides[1]
+            var i2 = t2.view.offset + j * t2.view.strides[1]
+            var i3 = t3.view.offset + j * t3.view.strides[1]
+            var i4 = t4.view.offset + j * t4.view.strides[1]
+            var i5 = t5.view.offset + j * t5.view.strides[1]
+            var i6 = t6.view.offset + j * t6.view.strides[1]
             for _ in 0..<destination.shape[0] {
                 var result = a0 * e0[i0]
                 result += a1 * e1[i1]
@@ -263,14 +263,14 @@ extension LazyMatrix where S == Double {
         let e3 = t3.view.storage.elements, e4 = t4.view.storage.elements, e6 = t6.view.storage.elements
         let a0 = t0.coefficient, a1 = t1.coefficient, a2 = t2.coefficient, a3 = t3.coefficient
         let a4 = terms[4].coefficient + terms[5].coefficient, a6 = t6.coefficient
-        for column in 0..<destination.shape[1] {
-            var d = destination.offset + column * destination.strides[1]
-            var i0 = t0.view.offset + column * t0.view.strides[1]
-            var i1 = t1.view.offset + column * t1.view.strides[1]
-            var i2 = t2.view.offset + column * t2.view.strides[1]
-            var i3 = t3.view.offset + column * t3.view.strides[1]
-            var i4 = t4.view.offset + column * t4.view.strides[1]
-            var i6 = t6.view.offset + column * t6.view.strides[1]
+        for j in 0..<destination.shape[1] {
+            var d = destination.offset + j * destination.strides[1]
+            var i0 = t0.view.offset + j * t0.view.strides[1]
+            var i1 = t1.view.offset + j * t1.view.strides[1]
+            var i2 = t2.view.offset + j * t2.view.strides[1]
+            var i3 = t3.view.offset + j * t3.view.strides[1]
+            var i4 = t4.view.offset + j * t4.view.strides[1]
+            var i6 = t6.view.offset + j * t6.view.strides[1]
             for _ in 0..<destination.shape[0] {
                 var result = a0 * e0[i0]
                 result += a1 * e1[i1]
@@ -299,14 +299,14 @@ extension LazyMatrix where S == Double {
         let source = t0.view.storage.elements, older = t6.view.storage.elements
         let a0 = t0.coefficient, a1 = t1.coefficient, a2 = t2.coefficient, a3 = t3.coefficient
         let a4 = terms[4].coefficient + terms[5].coefficient, a6 = t6.coefficient
-        for column in 0..<destination.shape[1] {
-            var d = destination.offset + column * destination.strides[1]
-            var i0 = t0.view.offset + column * t0.view.strides[1]
-            var i1 = t1.view.offset + column * t1.view.strides[1]
-            var i2 = t2.view.offset + column * t2.view.strides[1]
-            var i3 = t3.view.offset + column * t3.view.strides[1]
-            var i4 = t4.view.offset + column * t4.view.strides[1]
-            var i6 = t6.view.offset + column * t6.view.strides[1]
+        for j in 0..<destination.shape[1] {
+            var d = destination.offset + j * destination.strides[1]
+            var i0 = t0.view.offset + j * t0.view.strides[1]
+            var i1 = t1.view.offset + j * t1.view.strides[1]
+            var i2 = t2.view.offset + j * t2.view.strides[1]
+            var i3 = t3.view.offset + j * t3.view.strides[1]
+            var i4 = t4.view.offset + j * t4.view.strides[1]
+            var i6 = t6.view.offset + j * t6.view.strides[1]
             for _ in 0..<destination.shape[0] {
                 var result = a0 * source[i0]
                 result += a1 * source[i1]
@@ -333,14 +333,14 @@ extension LazyMatrix where S == Double {
         destination.storage.elements.withUnsafeMutableBufferPointer { destinationElements in
             t0.view.storage.elements.withUnsafeBufferPointer { source in
                 t6.view.storage.elements.withUnsafeBufferPointer { older in
-                    for column in 0..<destination.shape[1] {
-                        var d = destination.offset + column * destination.strides[1]
-                        var i0 = t0.view.offset + column * t0.view.strides[1]
-                        var i1 = t1.view.offset + column * t1.view.strides[1]
-                        var i2 = t2.view.offset + column * t2.view.strides[1]
-                        var i3 = t3.view.offset + column * t3.view.strides[1]
-                        var i4 = t4.view.offset + column * t4.view.strides[1]
-                        var i6 = t6.view.offset + column * t6.view.strides[1]
+                    for j in 0..<destination.shape[1] {
+                        var d = destination.offset + j * destination.strides[1]
+                        var i0 = t0.view.offset + j * t0.view.strides[1]
+                        var i1 = t1.view.offset + j * t1.view.strides[1]
+                        var i2 = t2.view.offset + j * t2.view.strides[1]
+                        var i3 = t3.view.offset + j * t3.view.strides[1]
+                        var i4 = t4.view.offset + j * t4.view.strides[1]
+                        var i6 = t6.view.offset + j * t6.view.strides[1]
                         for _ in 0..<destination.shape[0] {
                             var result = a0 * source[i0]
                             result += a1 * source[i1]

--- a/Sources/Tensors/Matrix/MatrixDenseBLAS.swift
+++ b/Sources/Tensors/Matrix/MatrixDenseBLAS.swift
@@ -48,8 +48,8 @@ extension MatrixDenseBLAS: PluMatrix {
     }
 
     public subscript(i: Int, j: Int) -> S {
-        get { value(row: i, column: j) }
-        set { setValue(newValue, row: i, column: j) }
+        get { value(i: i, j: j) }
+        set { setValue(newValue, i: i, j: j) }
     }
 
     public subscript(_ indices: [Int]) -> S {
@@ -57,13 +57,13 @@ extension MatrixDenseBLAS: PluMatrix {
             precondition(indices.count == 2, "MatrixDenseBLAS index rank must be 2")
             precondition(indices[0] >= 0 && indices[0] < rows, "Matrix row index out of bounds")
             precondition(indices[1] >= 0 && indices[1] < columns, "Matrix column index out of bounds")
-            return value(row: indices[0], column: indices[1])
+            return value(i: indices[0], j: indices[1])
         }
         set {
             precondition(indices.count == 2, "MatrixDenseBLAS index rank must be 2")
             precondition(indices[0] >= 0 && indices[0] < rows, "Matrix row index out of bounds")
             precondition(indices[1] >= 0 && indices[1] < columns, "Matrix column index out of bounds")
-            setValue(newValue, row: indices[0], column: indices[1])
+            setValue(newValue, i: indices[0], j: indices[1])
         }
     }
 
@@ -77,8 +77,8 @@ extension MatrixDenseBLAS: PluMatrix {
     public init(_ values: [[S]]) {
         let rows = values.count
         let columns = values[0].count
-        let elements = (0..<columns).flatMap { column in
-            (0..<rows).map { row in values[row][column] }
+        let elements = (0..<columns).flatMap { j in
+            (0..<rows).map { i in values[i][j] }
         }
         self.view = TensorFlatView(shape: [rows, columns], elements: elements)
         self.lazy = nil
@@ -114,9 +114,9 @@ extension MatrixDenseBLAS: PluMatrix {
     }
 
     public func toArray(round: Bool = false) -> [[S]] {
-        (0..<rows).map { row in
-            (0..<columns).map { column in
-                let value = value(row: row, column: column)
+        (0..<rows).map { i in
+            (0..<columns).map { j in
+                let value = value(i: i, j: j)
                 return round ? value.round() : value
             }
         }
@@ -174,24 +174,24 @@ extension MatrixDenseBLAS {
         }
     }
 
-    public subscript(row: Int, columns: Range<Int>) -> VectorFlatView<S> {
-        get { slice(row: row, columns: SliceRange(columns)) }
-        set { view.assign(newValue.view, to: [.index(row), TensorSliceIndex.range(columns)]) }
+    public subscript(i: Int, columns: Range<Int>) -> VectorFlatView<S> {
+        get { slice(row: i, columns: SliceRange(columns)) }
+        set { view.assign(newValue.view, to: [.index(i), TensorSliceIndex.range(columns)]) }
     }
 
-    public subscript(row: Int, columns: TensorSliceIndex) -> VectorFlatView<S> {
-        get { slice(row: row, columns: columns.sliceRange(dimensionSize: self.columns)) }
-        set { view.assign(newValue.view, to: [.index(row), columns]) }
+    public subscript(i: Int, columns: TensorSliceIndex) -> VectorFlatView<S> {
+        get { slice(row: i, columns: columns.sliceRange(dimensionSize: self.columns)) }
+        set { view.assign(newValue.view, to: [.index(i), columns]) }
     }
 
-    public subscript(rows: Range<Int>, column: Int) -> VectorFlatView<S> {
-        get { slice(rows: SliceRange(rows), column: column) }
-        set { view.assign(newValue.view, to: [TensorSliceIndex.range(rows), .index(column)]) }
+    public subscript(rows: Range<Int>, j: Int) -> VectorFlatView<S> {
+        get { slice(rows: SliceRange(rows), column: j) }
+        set { view.assign(newValue.view, to: [TensorSliceIndex.range(rows), .index(j)]) }
     }
 
-    public subscript(rows: TensorSliceIndex, column: Int) -> VectorFlatView<S> {
-        get { slice(rows: rows.sliceRange(dimensionSize: self.rows), column: column) }
-        set { view.assign(newValue.view, to: [rows, .index(column)]) }
+    public subscript(rows: TensorSliceIndex, j: Int) -> VectorFlatView<S> {
+        get { slice(rows: rows.sliceRange(dimensionSize: self.rows), column: j) }
+        set { view.assign(newValue.view, to: [rows, .index(j)]) }
     }
 }
 
@@ -415,9 +415,9 @@ extension MatrixDenseBLAS {
 
     public func transpose() -> MatrixDenseBLAS<S> {
         var transposed = MatrixDenseBLAS(rows: columns, columns: rows)
-        for row in 0..<rows {
-            for column in 0..<columns {
-                transposed.setValue(value(row: row, column: column), row: column, column: row)
+        for i in 0..<rows {
+            for j in 0..<columns {
+                transposed.setValue(value(i: i, j: j), i: j, j: i)
             }
         }
         return transposed
@@ -876,7 +876,7 @@ private func doubleSum(_ left: [Double], _ right: [Double]) -> [Double] {
     Array<Double>(unsafeUninitializedCapacity: left.count) { result, initializedCount in
         left.withUnsafeBufferPointer { left in
             right.withUnsafeBufferPointer { right in
-                for index in 0..<left.count { result[index] = left[index] + right[index] }
+                for i in 0..<left.count { result[i] = left[i] + right[i] }
             }
         }
         initializedCount = left.count
@@ -887,7 +887,7 @@ private func floatSum(_ left: [Float], _ right: [Float]) -> [Float] {
     Array<Float>(unsafeUninitializedCapacity: left.count) { result, initializedCount in
         left.withUnsafeBufferPointer { left in
             right.withUnsafeBufferPointer { right in
-                for index in 0..<left.count { result[index] = left[index] + right[index] }
+                for i in 0..<left.count { result[i] = left[i] + right[i] }
             }
         }
         initializedCount = left.count
@@ -898,7 +898,7 @@ private func doubleDifference(_ left: [Double], _ right: [Double]) -> [Double] {
     Array<Double>(unsafeUninitializedCapacity: left.count) { result, initializedCount in
         left.withUnsafeBufferPointer { left in
             right.withUnsafeBufferPointer { right in
-                for index in 0..<left.count { result[index] = left[index] - right[index] }
+                for i in 0..<left.count { result[i] = left[i] - right[i] }
             }
         }
         initializedCount = left.count
@@ -909,7 +909,7 @@ private func floatDifference(_ left: [Float], _ right: [Float]) -> [Float] {
     Array<Float>(unsafeUninitializedCapacity: left.count) { result, initializedCount in
         left.withUnsafeBufferPointer { left in
             right.withUnsafeBufferPointer { right in
-                for index in 0..<left.count { result[index] = left[index] - right[index] }
+                for i in 0..<left.count { result[i] = left[i] - right[i] }
             }
         }
         initializedCount = left.count
@@ -919,7 +919,7 @@ private func floatDifference(_ left: [Float], _ right: [Float]) -> [Float] {
 private func doubleScale(_ values: [Double], by scalar: Double) -> [Double] {
     Array<Double>(unsafeUninitializedCapacity: values.count) { result, initializedCount in
         values.withUnsafeBufferPointer { values in
-            for index in 0..<values.count { result[index] = values[index] * scalar }
+            for i in 0..<values.count { result[i] = values[i] * scalar }
         }
         initializedCount = values.count
     }
@@ -928,21 +928,21 @@ private func doubleScale(_ values: [Double], by scalar: Double) -> [Double] {
 private func floatScale(_ values: [Float], by scalar: Float) -> [Float] {
     Array<Float>(unsafeUninitializedCapacity: values.count) { result, initializedCount in
         values.withUnsafeBufferPointer { values in
-            for index in 0..<values.count { result[index] = values[index] * scalar }
+            for i in 0..<values.count { result[i] = values[i] * scalar }
         }
         initializedCount = values.count
     }
 }
 
 extension MatrixDenseBLAS {
-    private func value(row: Int, column: Int) -> S {
-        if let lazy { return lazy.value(row: row, column: column) }
-        return view.value(index0: row, index1: column)
+    private func value(i: Int, j: Int) -> S {
+        if let lazy { return lazy.value(i: i, j: j) }
+        return view.value(index0: i, index1: j)
     }
 
-    private mutating func setValue(_ value: S, row: Int, column: Int) {
+    private mutating func setValue(_ value: S, i: Int, j: Int) {
         materializeInPlace()
-        view.setValue(value, index0: row, index1: column)
+        view.setValue(value, index0: i, index1: j)
     }
 
     private mutating func assign(_ replacement: MatrixDenseBLAS<S>, to ranges: [SliceRange]) {
@@ -957,19 +957,19 @@ extension MatrixDenseBLAS {
     private func flattenedFromView(columnMajorOrder: Bool) -> [S] {
         var elements = Array(repeating: S.zero, count: rows * columns)
         if columnMajorOrder {
-            for column in 0..<columns {
-                for row in 0..<rows {
-                    let index = row + rows * column
-                    let storageIndex = view.offset + row * view.strides[0] + column * view.strides[1]
-                    elements[index] = view.storage.elements[storageIndex]
+            for j in 0..<columns {
+                for i in 0..<rows {
+                    let k = i + rows * j
+                    let storageIndex = view.offset + i * view.strides[0] + j * view.strides[1]
+                    elements[k] = view.storage.elements[storageIndex]
                 }
             }
         } else {
-            for row in 0..<rows {
-                for column in 0..<columns {
-                    let index = column + columns * row
-                    let storageIndex = view.offset + row * view.strides[0] + column * view.strides[1]
-                    elements[index] = view.storage.elements[storageIndex]
+            for i in 0..<rows {
+                for j in 0..<columns {
+                    let k = j + columns * i
+                    let storageIndex = view.offset + i * view.strides[0] + j * view.strides[1]
+                    elements[k] = view.storage.elements[storageIndex]
                 }
             }
         }
@@ -978,8 +978,8 @@ extension MatrixDenseBLAS {
 
     private func rowMajorElements(fromColumnMajorElements elements: [S]) -> [S] {
         var rowMajorElements = Array(repeating: S.zero, count: rows * columns)
-        for row in 0..<rows {
-            for column in 0..<columns { rowMajorElements[column + columns * row] = elements[row + rows * column] }
+        for i in 0..<rows {
+            for j in 0..<columns { rowMajorElements[j + columns * i] = elements[i + rows * j] }
         }
         return rowMajorElements
     }
@@ -1070,16 +1070,16 @@ extension MatrixDenseBLAS {
 
     private func luDeterminant<T: PluScalar>(from matrix: [T], pivots: [Int32], one: T) -> T {
         var result = one
-        for index in 0..<rows {
-            if pivots[index] != Int32(index + 1) { result = -result }
-            result *= matrix[index + rows * index]
+        for i in 0..<rows {
+            if pivots[i] != Int32(i + 1) { result = -result }
+            result *= matrix[i + rows * i]
         }
         return result
     }
 
     private func doubleIdentityElements() -> [Double] {
         var identity = Array(repeating: 0.0, count: rows * columns)
-        for index in 0..<rows { identity[index + rows * index] = 1.0 }
+        for i in 0..<rows { identity[i + rows * i] = 1.0 }
         return identity
     }
 
@@ -1231,21 +1231,21 @@ extension MatrixDenseBLAS: MatrixEigen where S == Double {
         real: [Double], imaginary: [Double], vectors: [Double]
     ) -> MatrixDenseBLAS<ComplexDouble> {
         var result = MatrixDenseBLAS<ComplexDouble>(rows: rows, columns: columns, initialValue: .zero)
-        var column = 0
-        while column < columns {
-            if imaginary[column] == 0.0 {
-                for row in 0..<rows {
-                    result[row, column] = ComplexDouble(vectors[row + rows * column], 0.0)
+        var j = 0
+        while j < columns {
+            if imaginary[j] == 0.0 {
+                for i in 0..<rows {
+                    result[i, j] = ComplexDouble(vectors[i + rows * j], 0.0)
                 }
-                column += 1
+                j += 1
             } else {
-                for row in 0..<rows {
-                    let realPart = vectors[row + rows * column]
-                    let imaginaryPart = vectors[row + rows * (column + 1)]
-                    result[row, column] = ComplexDouble(realPart, imaginaryPart)
-                    result[row, column + 1] = ComplexDouble(realPart, -imaginaryPart)
+                for i in 0..<rows {
+                    let realPart = vectors[i + rows * j]
+                    let imaginaryPart = vectors[i + rows * (j + 1)]
+                    result[i, j] = ComplexDouble(realPart, imaginaryPart)
+                    result[i, j + 1] = ComplexDouble(realPart, -imaginaryPart)
                 }
-                column += 2
+                j += 2
             }
         }
         return result

--- a/Sources/Tensors/Matrix/MatrixDenseBLAS.swift
+++ b/Sources/Tensors/Matrix/MatrixDenseBLAS.swift
@@ -77,9 +77,8 @@ extension MatrixDenseBLAS: PluMatrix {
     public init(_ values: [[S]]) {
         let rows = values.count
         let columns = values[0].count
-        let elements = (0..<columns).flatMap { j in
-            (0..<rows).map { i in values[i][j] }
-        }
+        let columnMajorOrdering: () -> [S] = { (0..<columns).flatMap { j in (0..<rows).map { i in values[i][j] }}}
+        let elements = columnMajorOrdering()
         self.view = TensorFlatView(shape: [rows, columns], elements: elements)
         self.lazy = nil
         self.blasImplementation = .default
@@ -199,11 +198,11 @@ extension MatrixDenseBLAS {
     public static func + (lhs: MatrixDenseBLAS<S>, rhs: MatrixDenseBLAS<S>) -> MatrixDenseBLAS<S> {
         precondition(lhs.shape == rhs.shape, "Tensors must have the same shape")
         if S.self == Double.self {
-            return doubleMatrixSum(lhs as! MatrixDenseBLAS<Double>, rhs as! MatrixDenseBLAS<Double>)
+            return matrixSumDouble(lhs as! MatrixDenseBLAS<Double>, rhs as! MatrixDenseBLAS<Double>)
                 as! MatrixDenseBLAS<S>
         }
         if S.self == Float.self {
-            return floatMatrixSum(lhs as! MatrixDenseBLAS<Float>, rhs as! MatrixDenseBLAS<Float>)
+            return matrixSumFloat(lhs as! MatrixDenseBLAS<Float>, rhs as! MatrixDenseBLAS<Float>)
                 as! MatrixDenseBLAS<S>
         }
         if lhs.isWholeMaterializedMatrix && rhs.isWholeMaterializedMatrix {
@@ -219,11 +218,11 @@ extension MatrixDenseBLAS {
     public static func - (lhs: MatrixDenseBLAS<S>, rhs: MatrixDenseBLAS<S>) -> MatrixDenseBLAS<S> {
         precondition(lhs.shape == rhs.shape, "Tensors must have the same shape")
         if S.self == Double.self {
-            return doubleMatrixDifference(lhs as! MatrixDenseBLAS<Double>, rhs as! MatrixDenseBLAS<Double>)
+            return matrixDifferenceDouble(lhs as! MatrixDenseBLAS<Double>, rhs as! MatrixDenseBLAS<Double>)
                 as! MatrixDenseBLAS<S>
         }
         if S.self == Float.self {
-            return floatMatrixDifference(lhs as! MatrixDenseBLAS<Float>, rhs as! MatrixDenseBLAS<Float>)
+            return matrixDifferenceFloat(lhs as! MatrixDenseBLAS<Float>, rhs as! MatrixDenseBLAS<Float>)
                 as! MatrixDenseBLAS<S>
         }
         return MatrixDenseBLAS(rows: lhs.rows, columns: lhs.columns,
@@ -237,10 +236,10 @@ extension MatrixDenseBLAS {
 
     public static func * (matrix: MatrixDenseBLAS<S>, scalar: S) -> MatrixDenseBLAS<S> {
         if S.self == Double.self {
-            return doubleMatrixScale(matrix as! MatrixDenseBLAS<Double>, by: scalar as! Double) as! MatrixDenseBLAS<S>
+            return matrixScaleDouble(matrix as! MatrixDenseBLAS<Double>, by: scalar as! Double) as! MatrixDenseBLAS<S>
         }
         if S.self == Float.self {
-            return floatMatrixScale(matrix as! MatrixDenseBLAS<Float>, by: scalar as! Float) as! MatrixDenseBLAS<S>
+            return matrixScaleFloat(matrix as! MatrixDenseBLAS<Float>, by: scalar as! Float) as! MatrixDenseBLAS<S>
         }
         return MatrixDenseBLAS(rows: matrix.rows, columns: matrix.columns,
                                lazy: matrix.lazyMatrix.scaled(by: scalar),
@@ -432,26 +431,26 @@ extension MatrixDenseBLAS {
 
 public func + (lhs: MatrixDenseBLAS<Double>, rhs: MatrixDenseBLAS<Double>) -> MatrixDenseBLAS<Double> {
     precondition(lhs.shape == rhs.shape, "Tensors must have the same shape")
-    return doubleMatrixSum(lhs, rhs)
+    return matrixSumDouble(lhs, rhs)
 }
 
 public func + (lhs: MatrixDenseBLAS<Float>, rhs: MatrixDenseBLAS<Float>) -> MatrixDenseBLAS<Float> {
     precondition(lhs.shape == rhs.shape, "Tensors must have the same shape")
-    return floatMatrixSum(lhs, rhs)
+    return matrixSumFloat(lhs, rhs)
 }
 
 public func - (lhs: MatrixDenseBLAS<Double>, rhs: MatrixDenseBLAS<Double>) -> MatrixDenseBLAS<Double> {
     precondition(lhs.shape == rhs.shape, "Tensors must have the same shape")
-    return doubleMatrixDifference(lhs, rhs)
+    return matrixDifferenceDouble(lhs, rhs)
 }
 
 public func - (lhs: MatrixDenseBLAS<Float>, rhs: MatrixDenseBLAS<Float>) -> MatrixDenseBLAS<Float> {
     precondition(lhs.shape == rhs.shape, "Tensors must have the same shape")
-    return floatMatrixDifference(lhs, rhs)
+    return matrixDifferenceFloat(lhs, rhs)
 }
 
 public func * (matrix: MatrixDenseBLAS<Double>, scalar: Double) -> MatrixDenseBLAS<Double> {
-    doubleMatrixScale(matrix, by: scalar)
+    matrixScaleDouble(matrix, by: scalar)
 }
 
 public func * (scalar: Double, matrix: MatrixDenseBLAS<Double>) -> MatrixDenseBLAS<Double> {
@@ -463,7 +462,7 @@ public func / (matrix: MatrixDenseBLAS<Double>, scalar: Double) -> MatrixDenseBL
 }
 
 public func * (matrix: MatrixDenseBLAS<Float>, scalar: Float) -> MatrixDenseBLAS<Float> {
-    floatMatrixScale(matrix, by: scalar)
+    matrixScaleFloat(matrix, by: scalar)
 }
 
 public func * (scalar: Float, matrix: MatrixDenseBLAS<Float>) -> MatrixDenseBLAS<Float> {
@@ -471,11 +470,11 @@ public func * (scalar: Float, matrix: MatrixDenseBLAS<Float>) -> MatrixDenseBLAS
 }
 
 public func * (left: MatrixDenseBLAS<Double>, right: MatrixDenseBLAS<Double>) -> MatrixDenseBLAS<Double> {
-    doubleMatrixProduct(left, right)
+    matrixProductDouble(left, right)
 }
 
 public func * (left: MatrixDenseBLAS<Float>, right: MatrixDenseBLAS<Float>) -> MatrixDenseBLAS<Float> {
-    floatMatrixProduct(left, right)
+    matrixProductFloat(left, right)
 }
 
 public func * (left: MatrixDenseBLAS<ComplexDouble>, right: MatrixDenseBLAS<ComplexDouble>)
@@ -485,32 +484,32 @@ public func * (left: MatrixDenseBLAS<ComplexDouble>, right: MatrixDenseBLAS<Comp
 
 public func * (left: MatrixDenseBLAS<ComplexFloat>, right: MatrixDenseBLAS<ComplexFloat>)
     -> MatrixDenseBLAS<ComplexFloat> {
-    complexFloatMatrixProduct(left, right)
+    matrixProductComplexFloat(left, right)
 }
 
 public func * (matrix: MatrixDenseBLAS<Double>, vector: VectorDenseBLAS<Double>) -> VectorDenseBLAS<Double> {
-    doubleMatrixVectorProduct(matrix, vector)
+    vectorProductDoubleMatrix(matrix, vector)
 }
 
 public func * (matrix: MatrixDenseBLAS<Float>, vector: VectorDenseBLAS<Float>) -> VectorDenseBLAS<Float> {
-    floatMatrixVectorProduct(matrix, vector)
+    vectorProductFloatMatrix(matrix, vector)
 }
 
 public func * (matrix: MatrixDenseBLAS<ComplexDouble>, vector: VectorDenseBLAS<ComplexDouble>)
     -> VectorDenseBLAS<ComplexDouble> {
-    complexDoubleMatrixVectorProduct(matrix, vector)
+    matrixVectorProductComplexDouble(matrix, vector)
 }
 
 public func * (matrix: MatrixDenseBLAS<ComplexFloat>, vector: VectorDenseBLAS<ComplexFloat>)
     -> VectorDenseBLAS<ComplexFloat> {
-    complexFloatMatrixVectorProduct(matrix, vector)
+    vectorProductComplexFloatMatrix(matrix, vector)
 }
 
 public func / (matrix: MatrixDenseBLAS<Float>, scalar: Float) -> MatrixDenseBLAS<Float> {
     matrix * (Float(1.0) / scalar)
 }
 
-private func doubleMatrixSum(
+private func matrixSumDouble(
     _ lhs: MatrixDenseBLAS<Double>, _ rhs: MatrixDenseBLAS<Double>
 ) -> MatrixDenseBLAS<Double> {
     if lhs.isWholeMaterializedMatrix && rhs.isWholeMaterializedMatrix {
@@ -523,7 +522,7 @@ private func doubleMatrixSum(
                            blasImplementation: lhs.blasImplementation)
 }
 
-private func floatMatrixSum(_ lhs: MatrixDenseBLAS<Float>, _ rhs: MatrixDenseBLAS<Float>) -> MatrixDenseBLAS<Float> {
+private func matrixSumFloat(_ lhs: MatrixDenseBLAS<Float>, _ rhs: MatrixDenseBLAS<Float>) -> MatrixDenseBLAS<Float> {
     if lhs.isWholeMaterializedMatrix && rhs.isWholeMaterializedMatrix {
         return MatrixDenseBLAS(rows: lhs.rows, columns: lhs.columns,
                                values: floatSum(lhs.view.storage.elements, rhs.view.storage.elements),
@@ -534,7 +533,7 @@ private func floatMatrixSum(_ lhs: MatrixDenseBLAS<Float>, _ rhs: MatrixDenseBLA
                            blasImplementation: lhs.blasImplementation)
 }
 
-private func doubleMatrixDifference(
+private func matrixDifferenceDouble(
     _ lhs: MatrixDenseBLAS<Double>, _ rhs: MatrixDenseBLAS<Double>
 ) -> MatrixDenseBLAS<Double> {
     if lhs.isWholeMaterializedMatrix && rhs.isWholeMaterializedMatrix {
@@ -547,7 +546,7 @@ private func doubleMatrixDifference(
                            blasImplementation: lhs.blasImplementation)
 }
 
-private func floatMatrixDifference(
+private func matrixDifferenceFloat(
     _ lhs: MatrixDenseBLAS<Float>, _ rhs: MatrixDenseBLAS<Float>
 ) -> MatrixDenseBLAS<Float> {
     if lhs.isWholeMaterializedMatrix && rhs.isWholeMaterializedMatrix {
@@ -560,7 +559,7 @@ private func floatMatrixDifference(
                            blasImplementation: lhs.blasImplementation)
 }
 
-private func doubleMatrixScale(_ matrix: MatrixDenseBLAS<Double>, by scalar: Double) -> MatrixDenseBLAS<Double> {
+private func matrixScaleDouble(_ matrix: MatrixDenseBLAS<Double>, by scalar: Double) -> MatrixDenseBLAS<Double> {
     if matrix.isWholeMaterializedMatrix {
         return MatrixDenseBLAS(rows: matrix.rows, columns: matrix.columns,
                                values: doubleScale(matrix.view.storage.elements, by: scalar),
@@ -571,7 +570,7 @@ private func doubleMatrixScale(_ matrix: MatrixDenseBLAS<Double>, by scalar: Dou
                            blasImplementation: matrix.blasImplementation)
 }
 
-private func floatMatrixScale(_ matrix: MatrixDenseBLAS<Float>, by scalar: Float) -> MatrixDenseBLAS<Float> {
+private func matrixScaleFloat(_ matrix: MatrixDenseBLAS<Float>, by scalar: Float) -> MatrixDenseBLAS<Float> {
     if matrix.isWholeMaterializedMatrix {
         return MatrixDenseBLAS(rows: matrix.rows, columns: matrix.columns,
                                values: floatScale(matrix.view.storage.elements, by: scalar),
@@ -582,7 +581,7 @@ private func floatMatrixScale(_ matrix: MatrixDenseBLAS<Float>, by scalar: Float
                            blasImplementation: matrix.blasImplementation)
 }
 
-private func doubleMatrixProduct(
+private func matrixProductDouble(
     _ left: MatrixDenseBLAS<Double>, _ right: MatrixDenseBLAS<Double>
 ) -> MatrixDenseBLAS<Double> {
     precondition(left.columns == right.rows, "Number of matrix columns must match matrix rows")
@@ -605,7 +604,7 @@ private func doubleMatrixProduct(
                                    blasImplementation: left.blasImplementation)
 }
 
-private func floatMatrixProduct(_ left: MatrixDenseBLAS<Float>, _ right: MatrixDenseBLAS<Float>)
+private func matrixProductFloat(_ left: MatrixDenseBLAS<Float>, _ right: MatrixDenseBLAS<Float>)
     -> MatrixDenseBLAS<Float> {
     precondition(left.columns == right.rows, "Number of matrix columns must match matrix rows")
     let leftElements = left.columnMajorStorage()
@@ -648,7 +647,7 @@ private func complexDoubleMatrixProduct(
                                           blasImplementation: left.blasImplementation)
 }
 
-private func complexFloatMatrixProduct(
+private func matrixProductComplexFloat(
     _ left: MatrixDenseBLAS<ComplexFloat>, _ right: MatrixDenseBLAS<ComplexFloat>
 ) -> MatrixDenseBLAS<ComplexFloat> {
     precondition(left.columns == right.rows, "Number of matrix columns must match matrix rows")
@@ -669,7 +668,7 @@ private func complexFloatMatrixProduct(
                                          blasImplementation: left.blasImplementation)
 }
 
-private func doubleMatrixVectorProduct(
+private func vectorProductDoubleMatrix(
     _ matrix: MatrixDenseBLAS<Double>, _ vector: VectorDenseBLAS<Double>
 ) -> VectorDenseBLAS<Double> {
     precondition(matrix.columns == vector.size, "Number of columns in matrix must equal size of vector")
@@ -691,7 +690,7 @@ private func doubleMatrixVectorProduct(
     return VectorDenseBLAS<Double>(result)
 }
 
-private func floatMatrixVectorProduct(
+private func vectorProductFloatMatrix(
     _ matrix: MatrixDenseBLAS<Float>, _ vector: VectorDenseBLAS<Float>
 ) -> VectorDenseBLAS<Float> {
     precondition(matrix.columns == vector.size, "Number of columns in matrix must equal size of vector")
@@ -713,7 +712,7 @@ private func floatMatrixVectorProduct(
     return VectorDenseBLAS<Float>(result)
 }
 
-private func complexDoubleMatrixVectorProduct(
+private func matrixVectorProductComplexDouble(
     _ matrix: MatrixDenseBLAS<ComplexDouble>, _ vector: VectorDenseBLAS<ComplexDouble>
 ) -> VectorDenseBLAS<ComplexDouble> {
     precondition(matrix.columns == vector.size, "Number of columns in matrix must equal size of vector")
@@ -735,7 +734,7 @@ private func complexDoubleMatrixVectorProduct(
     return VectorDenseBLAS<ComplexDouble>(result)
 }
 
-private func complexFloatMatrixVectorProduct(
+private func vectorProductComplexFloatMatrix(
     _ matrix: MatrixDenseBLAS<ComplexFloat>, _ vector: VectorDenseBLAS<ComplexFloat>
 ) -> VectorDenseBLAS<ComplexFloat> {
     precondition(matrix.columns == vector.size, "Number of columns in matrix must equal size of vector")

--- a/Sources/Tensors/Matrix/MatrixDenseBLAS.swift
+++ b/Sources/Tensors/Matrix/MatrixDenseBLAS.swift
@@ -297,7 +297,7 @@ extension MatrixDenseBLAS {
             case .openBLAS:
                 OpenBLASOperations.zgemv(Int32(rows), Int32(columns), &A, &x, &y)
             }
-            return V(BLASComplexStorage.complexValues(y) as! [S])
+            return V(BLASComplexStorage.toComplex(y) as! [S])
         case is ComplexFloat.Type:
             var A = BLASComplexStorage.interleaved(flatten() as! [ComplexFloat])
             var x = BLASComplexStorage.interleaved(v.toArray(round: false) as! [ComplexFloat])
@@ -310,7 +310,7 @@ extension MatrixDenseBLAS {
             case .openBLAS:
                 OpenBLASOperations.cgemv(Int32(rows), Int32(columns), &A, &x, &y)
             }
-            return V(BLASComplexStorage.complexValues(y) as! [S])
+            return V(BLASComplexStorage.toComplex(y) as! [S])
         default:
             fatalError("Unsupported scalar type")
         }
@@ -357,7 +357,7 @@ extension MatrixDenseBLAS {
             case .openBLAS:
                 OpenBLASOperations.zgemm(Int32(rows), Int32(m.columns), Int32(columns), &A, &B, &C)
             }
-            return MatrixDenseBLAS(rows: rows, columns: m.columns, values: BLASComplexStorage.complexValues(C) as! [S])
+            return MatrixDenseBLAS(rows: rows, columns: m.columns, values: BLASComplexStorage.toComplex(C) as! [S])
         case is ComplexFloat.Type:
             var A = BLASComplexStorage.interleaved(flatten() as! [ComplexFloat])
             var B = BLASComplexStorage.interleaved(m.flatten() as! [ComplexFloat])
@@ -370,7 +370,7 @@ extension MatrixDenseBLAS {
             case .openBLAS:
                 OpenBLASOperations.cgemm(Int32(rows), Int32(m.columns), Int32(columns), &A, &B, &C)
             }
-            let values = BLASComplexStorage.complexValues(C) as! [S]
+            let values = BLASComplexStorage.toComplex(C) as! [S]
             return MatrixDenseBLAS(rows: rows, columns: m.columns, values: values)
         default:
             fatalError("Unsupported scalar type")
@@ -1056,7 +1056,7 @@ extension MatrixDenseBLAS {
         let factorization = complexDoubleFactorization()
         precondition(factorization.info >= 0, "LAPACK determinant failed with info \(factorization.info)")
         if factorization.info > 0 { return .zero }
-        let matrix = BLASComplexStorage.complexValues(factorization.matrix) as [ComplexDouble]
+        let matrix = BLASComplexStorage.toComplex(factorization.matrix) as [ComplexDouble]
         return luDeterminant(from: matrix, pivots: factorization.pivots, one: ComplexDouble(1.0, 0.0))
     }
 
@@ -1064,7 +1064,7 @@ extension MatrixDenseBLAS {
         let factorization = complexFloatFactorization()
         precondition(factorization.info >= 0, "LAPACK determinant failed with info \(factorization.info)")
         if factorization.info > 0 { return .zero }
-        let matrix = BLASComplexStorage.complexValues(factorization.matrix) as [ComplexFloat]
+        let matrix = BLASComplexStorage.toComplex(factorization.matrix) as [ComplexFloat]
         return luDeterminant(from: matrix, pivots: factorization.pivots, one: ComplexFloat(1.0, 0.0))
     }
 
@@ -1106,7 +1106,7 @@ extension MatrixDenseBLAS {
         let info = complexDoubleGetri(Int32(rows), &factorization.matrix, factorization.pivots)
         precondition(info == 0, "LAPACK inverse failed with info \(info)")
         return MatrixDenseBLAS<ComplexDouble>(rows: rows, columns: columns,
-                                              values: BLASComplexStorage.complexValues(factorization.matrix))
+                                              values: BLASComplexStorage.toComplex(factorization.matrix))
     }
 
     private func complexFloatInverse() -> MatrixDenseBLAS<ComplexFloat> {
@@ -1115,7 +1115,7 @@ extension MatrixDenseBLAS {
         let info = complexFloatGetri(Int32(rows), &factorization.matrix, factorization.pivots)
         precondition(info == 0, "LAPACK inverse failed with info \(info)")
         return MatrixDenseBLAS<ComplexFloat>(rows: rows, columns: columns,
-                                             values: BLASComplexStorage.complexValues(factorization.matrix))
+                                             values: BLASComplexStorage.toComplex(factorization.matrix))
     }
 
     private func doubleGetrf(_ n: Int32, _ matrix: inout [Double]) -> (pivots: [Int32], info: Int32) {

--- a/Sources/Tensors/Matrix/MatrixDenseReference.swift
+++ b/Sources/Tensors/Matrix/MatrixDenseReference.swift
@@ -39,8 +39,8 @@ extension MatrixDenseReference: PluMatrix {
 
     public init(rows: Int, columns: Int, values: [S]) {
         precondition(values.count == rows * columns, "Matrix value count must match matrix shape")
-        self.elements = (0..<rows).map { row in
-            (0..<columns).map { column in values[row + rows * column] }
+        self.elements = (0..<rows).map { i in
+            (0..<columns).map { j in values[i + rows * j] }
         }
     }
 
@@ -125,8 +125,8 @@ extension MatrixDenseReference {
 
     private static func rows(from values: TensorNestedArray<S>) -> [[S]] {
         let shape = values.shape
-        return (0..<shape[0]).map { row in
-            (0..<shape[1]).map { column in values[[row, column]] }
+        return (0..<shape[0]).map { i in
+            (0..<shape[1]).map { j in values[[i, j]] }
         }
     }
 }

--- a/Sources/Tensors/Matrix/MatrixFlatView.swift
+++ b/Sources/Tensors/Matrix/MatrixFlatView.swift
@@ -24,7 +24,7 @@ extension MatrixFlatView: MatrixView {
     public init(_ values: [[Scalar]]) {
         let rows = values.count
         let columns = values[0].count
-        let elements = (0..<columns).flatMap { column in (0..<rows).map { row in values[row][column] } }
+        let elements = (0..<columns).flatMap { j in (0..<rows).map { i in values[i][j] } }
         self.init(view: TensorFlatView(shape: [rows, columns], elements: elements))
     }
 
@@ -44,9 +44,9 @@ extension MatrixFlatView: MatrixView {
         }
     }
 
-    public subscript(row: Int, column: Int) -> Scalar {
-        get { view[[row, column]] }
-        set { view[[row, column]] = newValue }
+    public subscript(i: Int, j: Int) -> Scalar {
+        get { view[[i, j]] }
+        set { view[[i, j]] = newValue }
     }
 }
 
@@ -70,20 +70,20 @@ extension MatrixFlatView {
         )
     }
 
-    public subscript(row: Int, columns: Range<Int>) -> VectorFlatView<Scalar> {
-        slice(row: row, columns: SliceRange(columns))
+    public subscript(i: Int, columns: Range<Int>) -> VectorFlatView<Scalar> {
+        slice(row: i, columns: SliceRange(columns))
     }
 
-    public subscript(row: Int, columns: TensorSliceIndex) -> VectorFlatView<Scalar> {
-        slice(row: row, columns: columns.sliceRange(dimensionSize: self.columns))
+    public subscript(i: Int, columns: TensorSliceIndex) -> VectorFlatView<Scalar> {
+        slice(row: i, columns: columns.sliceRange(dimensionSize: self.columns))
     }
 
-    public subscript(rows: Range<Int>, column: Int) -> VectorFlatView<Scalar> {
-        slice(rows: SliceRange(rows), column: column)
+    public subscript(rows: Range<Int>, j: Int) -> VectorFlatView<Scalar> {
+        slice(rows: SliceRange(rows), column: j)
     }
 
-    public subscript(rows: TensorSliceIndex, column: Int) -> VectorFlatView<Scalar> {
-        slice(rows: rows.sliceRange(dimensionSize: self.rows), column: column)
+    public subscript(rows: TensorSliceIndex, j: Int) -> VectorFlatView<Scalar> {
+        slice(rows: rows.sliceRange(dimensionSize: self.rows), column: j)
     }
 
     public func slice(rows: SliceRange, columns: SliceRange) -> MatrixFlatView<Scalar> {
@@ -119,7 +119,7 @@ extension MatrixFlatView {
     }
 
     public func toArray() -> [[Scalar]] {
-        (0..<rows).map { row in (0..<columns).map { column in self[row, column] } }
+        (0..<rows).map { i in (0..<columns).map { j in self[i, j] } }
     }
 }
 
@@ -132,10 +132,10 @@ extension MatrixFlatView {
 extension MatrixFlatView {
     private func flattenedFromView(columnMajorOrder: Bool) -> [Scalar] {
         var elements = Array(repeating: Scalar.zero, count: rows * columns)
-        for row in 0..<rows {
-            for column in 0..<columns {
-                let index = columnMajorOrder ? row + rows * column : column + columns * row
-                elements[index] = self[row, column]
+        for i in 0..<rows {
+            for j in 0..<columns {
+                let k = columnMajorOrder ? i + rows * j : j + columns * i
+                elements[k] = self[i, j]
             }
         }
         return elements

--- a/Sources/Tensors/Matrix/MatrixFlatView.swift
+++ b/Sources/Tensors/Matrix/MatrixFlatView.swift
@@ -24,7 +24,8 @@ extension MatrixFlatView: MatrixView {
     public init(_ values: [[Scalar]]) {
         let rows = values.count
         let columns = values[0].count
-        let elements = (0..<columns).flatMap { j in (0..<rows).map { i in values[i][j] } }
+        let columnMajorOrdering: () -> [S] = { (0..<columns).flatMap { j in (0..<rows).map { i in values[i][j] }}}
+        let elements = columnMajorOrdering()
         self.init(view: TensorFlatView(shape: [rows, columns], elements: elements))
     }
 

--- a/Sources/Tensors/Matrix/MatrixView.swift
+++ b/Sources/Tensors/Matrix/MatrixView.swift
@@ -2,5 +2,5 @@ public protocol MatrixView: TensorView {
     var rows: Int { get }
     var columns: Int { get }
 
-    subscript(row: Int, column: Int) -> Scalar { get set }
+    subscript(i: Int, j: Int) -> Scalar { get set }
 }

--- a/Sources/Tensors/Protocols/MatrixArithmetic.swift
+++ b/Sources/Tensors/Protocols/MatrixArithmetic.swift
@@ -11,8 +11,8 @@ extension MatrixArithmetic where Self: PluMatrix {
     public var tr: S {
         precondition(rows == columns, "Trace requires a square matrix")
         var sum = S.zero
-        for index in 0..<rows {
-            sum += self[index, index]
+        for i in 0..<rows {
+            sum += self[i, i]
         }
         return sum
     }

--- a/Sources/Tensors/Protocols/MatrixArithmeticReference.swift
+++ b/Sources/Tensors/Protocols/MatrixArithmeticReference.swift
@@ -8,19 +8,19 @@ extension MatrixArithmeticReference {
         var values = toArray()
         var sign: S = 1
         var result: S = 1
-        for column in 0..<columns {
-            guard let pivot = (column..<rows).first(where: { values[$0][column] != .zero }) else { return .zero }
-            if pivot != column {
-                values.swapAt(pivot, column)
+        for j in 0..<columns {
+            guard let pivot = (j..<rows).first(where: { values[$0][j] != .zero }) else { return .zero }
+            if pivot != j {
+                values.swapAt(pivot, j)
                 sign = -sign
             }
-            let pivotValue = values[column][column]
+            let pivotValue = values[j][j]
             result *= pivotValue
-            if column + 1 < rows {
-                for row in (column + 1)..<rows {
-                    let factor = values[row][column] / pivotValue
-                    for entry in column..<columns {
-                        values[row][entry] -= factor * values[column][entry]
+            if j + 1 < rows {
+                for i in (j + 1)..<rows {
+                    let factor = values[i][j] / pivotValue
+                    for k in j..<columns {
+                        values[i][k] -= factor * values[j][k]
                     }
                 }
             }
@@ -32,24 +32,24 @@ extension MatrixArithmeticReference {
         precondition(rows == columns, "Inverse requires a square matrix")
         var left = toArray()
         var right = Self.identityArray(size: rows)
-        for column in 0..<columns {
-            guard let pivot = (column..<rows).first(where: { left[$0][column] != .zero }) else {
+        for j in 0..<columns {
+            guard let pivot = (j..<rows).first(where: { left[$0][j] != .zero }) else {
                 preconditionFailure("Matrix must be invertible")
             }
-            if pivot != column {
-                left.swapAt(pivot, column)
-                right.swapAt(pivot, column)
+            if pivot != j {
+                left.swapAt(pivot, j)
+                right.swapAt(pivot, j)
             }
-            let pivotValue = left[column][column]
-            for entry in 0..<columns {
-                left[column][entry] = left[column][entry] / pivotValue
-                right[column][entry] = right[column][entry] / pivotValue
+            let pivotValue = left[j][j]
+            for k in 0..<columns {
+                left[j][k] = left[j][k] / pivotValue
+                right[j][k] = right[j][k] / pivotValue
             }
-            for row in 0..<rows where row != column {
-                let factor = left[row][column]
-                for entry in 0..<columns {
-                    left[row][entry] -= factor * left[column][entry]
-                    right[row][entry] -= factor * right[column][entry]
+            for i in 0..<rows where i != j {
+                let factor = left[i][j]
+                for k in 0..<columns {
+                    left[i][k] -= factor * left[j][k]
+                    right[i][k] -= factor * right[j][k]
                 }
             }
         }
@@ -57,8 +57,8 @@ extension MatrixArithmeticReference {
     }
 
     private static func identityArray(size: Int) -> [[S]] {
-        (0..<size).map { row in
-            (0..<size).map { column in row == column ? 1 : 0 }
+        (0..<size).map { i in
+            (0..<size).map { j in i == j ? 1 : 0 }
         }
     }
 }

--- a/Sources/Tensors/Protocols/TensorArithmetic.swift
+++ b/Sources/Tensors/Protocols/TensorArithmetic.swift
@@ -7,10 +7,17 @@ public protocol TensorArithmetic: Equatable {
     static func * (tensor: Self, scalar: S) -> Self
     static func * (scalar: S, tensor: Self) -> Self
     static func / (tensor: Self, scalar: S) -> Self
-    func isApproximatelyEqual(to other: Self, relativeTolerance: S.Magnitude, norm: (Self) -> S.Magnitude) -> Bool
+    func isClose(to other: Self, relativeTolerance: S.Magnitude, norm: (Self) -> S.Magnitude) -> Bool
 }
 
 extension TensorArithmetic {
+    public func isClose(
+        to other: Self,
+        relativeTolerance: S.Magnitude = S.Magnitude.ulpOfOne.squareRoot()
+    ) -> Bool {
+        isClose(to: other, relativeTolerance: relativeTolerance, norm: { _ in .zero })
+    }
+
     public static func - (lhs: Self, rhs: Self) -> Self {
         return lhs + (-rhs)
     }

--- a/Sources/Tensors/Protocols/TensorArithmeticBLAS.swift
+++ b/Sources/Tensors/Protocols/TensorArithmeticBLAS.swift
@@ -32,14 +32,14 @@ extension TensorArithmeticBLAS {
         return tensor * (one / scalar)
     }
 
-    public func isApproximatelyEqual(
+    public func isClose(
         to other: Self,
         relativeTolerance: S.Magnitude = S.Magnitude.ulpOfOne.squareRoot(),
         norm: (Self) -> S.Magnitude = { _ in .zero }
     ) -> Bool {
         guard shape == other.shape else { return false }
         for (left, right) in zip(elements, other.elements) {
-            if !left.isApproximatelyEqual(to: right, relativeTolerance: relativeTolerance) { return false }
+            if !left.isClose(to: right, relativeTolerance: relativeTolerance) { return false }
         }
         return true
     }
@@ -79,12 +79,12 @@ extension TensorArithmeticBLAS {
             var result = BLASComplexStorage.interleaved(values as! [ComplexDouble])
             var alpha = BLASComplexStorage.interleaved([scalar as! ComplexDouble])
             BLAS.zscal(Int32(values.count), &alpha, &result)
-            return BLASComplexStorage.complexValues(result) as! [S]
+            return BLASComplexStorage.toComplex(result) as! [S]
         case is ComplexFloat.Type:
             var result = BLASComplexStorage.interleaved(values as! [ComplexFloat])
             var alpha = BLASComplexStorage.interleaved([scalar as! ComplexFloat])
             BLAS.cscal(Int32(values.count), &alpha, &result)
-            return BLASComplexStorage.complexValues(result) as! [S]
+            return BLASComplexStorage.toComplex(result) as! [S]
         default:
             fatalError("Unsupported scalar type")
         }

--- a/Sources/Tensors/Protocols/TensorArithmeticReference.swift
+++ b/Sources/Tensors/Protocols/TensorArithmeticReference.swift
@@ -7,24 +7,24 @@ extension TensorArithmeticReference {
     public static func + (lhs: Self, rhs: Self) -> Self {
         precondition(lhs.shape == rhs.shape, "Tensors must have the same shape")
         var result = Self(shape: lhs.shape, initialValue: .zero)
-        for index in indexCombinations(for: lhs.shape) {
-            result[index] = lhs[index] + rhs[index]
+        for i in indexCombinations(for: lhs.shape) {
+            result[i] = lhs[i] + rhs[i]
         }
         return result
     }
 
     public static prefix func - (operand: Self) -> Self {
         var result = Self(shape: operand.shape, initialValue: .zero)
-        for index in indexCombinations(for: operand.shape) {
-            result[index] = -operand[index]
+        for i in indexCombinations(for: operand.shape) {
+            result[i] = -operand[i]
         }
         return result
     }
 
     public static func * (tensor: Self, scalar: S) -> Self {
         var result = Self(shape: tensor.shape, initialValue: .zero)
-        for index in indexCombinations(for: tensor.shape) {
-            result[index] = tensor[index] * scalar
+        for i in indexCombinations(for: tensor.shape) {
+            result[i] = tensor[i] * scalar
         }
         return result
     }
@@ -35,8 +35,8 @@ extension TensorArithmeticReference {
 
     public static func / (tensor: Self, scalar: S) -> Self {
         var result = Self(shape: tensor.shape, initialValue: .zero)
-        for index in indexCombinations(for: tensor.shape) {
-            result[index] = tensor[index] / scalar
+        for i in indexCombinations(for: tensor.shape) {
+            result[i] = tensor[i] / scalar
         }
         return result
     }
@@ -47,8 +47,8 @@ extension TensorArithmeticReference {
         norm: (Self) -> S.Magnitude = { _ in .zero }
     ) -> Bool {
         guard shape == other.shape else { return false }
-        for index in Self.indexCombinations(for: shape) {
-            if !self[index].isClose(to: other[index], relativeTolerance: relativeTolerance) {
+        for i in Self.indexCombinations(for: shape) {
+            if !self[i].isClose(to: other[i], relativeTolerance: relativeTolerance) {
                 return false
             }
         }
@@ -62,9 +62,9 @@ extension TensorArithmeticReference {
         return (0..<shape.reduce(1, *)).map { flatIndex in
             var remaining = flatIndex
             return shape.map { dimension in
-                let index = remaining % dimension
+                let i = remaining % dimension
                 remaining /= dimension
-                return index
+                return i
             }
         }
     }

--- a/Sources/Tensors/Protocols/TensorArithmeticReference.swift
+++ b/Sources/Tensors/Protocols/TensorArithmeticReference.swift
@@ -41,14 +41,14 @@ extension TensorArithmeticReference {
         return result
     }
 
-    public func isApproximatelyEqual(
+    public func isClose(
         to other: Self,
         relativeTolerance: S.Magnitude = S.Magnitude.ulpOfOne.squareRoot(),
         norm: (Self) -> S.Magnitude = { _ in .zero }
     ) -> Bool {
         guard shape == other.shape else { return false }
         for index in Self.indexCombinations(for: shape) {
-            if !self[index].isApproximatelyEqual(to: other[index], relativeTolerance: relativeTolerance) {
+            if !self[index].isClose(to: other[index], relativeTolerance: relativeTolerance) {
                 return false
             }
         }

--- a/Sources/Tensors/Protocols/TensorIndex.swift
+++ b/Sources/Tensors/Protocols/TensorIndex.swift
@@ -192,9 +192,9 @@ private func indexCombinations(for shape: [Int]) -> [[Int]] {
     return (0..<shape.reduce(1, *)).map { flatIndex in
         var remaining = flatIndex
         return shape.map { dimension in
-            let index = remaining % dimension
+            let i = remaining % dimension
             remaining /= dimension
-            return index
+            return i
         }
     }
 }

--- a/Sources/Tensors/Protocols/TensorMixedScalarArithmetic.swift
+++ b/Sources/Tensors/Protocols/TensorMixedScalarArithmetic.swift
@@ -6,9 +6,9 @@ private func mixedScalarIndexCombinations(for shape: [Int]) -> [[Int]] {
     return (0..<shape.reduce(1, *)).map { flatIndex in
         var remaining = flatIndex
         return shape.map { dimension in
-            let index = remaining % dimension
+            let i = remaining % dimension
             remaining /= dimension
-            return index
+            return i
         }
     }
 }
@@ -16,8 +16,8 @@ private func mixedScalarIndexCombinations(for shape: [Int]) -> [[Int]] {
 public func * <T: TensorArithmeticReference>(tensor: T, scalar: ComplexDouble) -> TensorDenseBLAS<ComplexDouble>
     where T.S == Double {
     var result = TensorDenseBLAS<ComplexDouble>(shape: tensor.shape, initialValue: .zero)
-    for index in mixedScalarIndexCombinations(for: tensor.shape) {
-        result[index] = tensor[index] * scalar
+    for i in mixedScalarIndexCombinations(for: tensor.shape) {
+        result[i] = tensor[i] * scalar
     }
     return result
 }
@@ -30,16 +30,16 @@ public func * <T: TensorArithmeticReference>(scalar: ComplexDouble, tensor: T) -
 public func / <T: TensorArithmeticReference>(tensor: T, scalar: ComplexDouble) -> TensorDenseBLAS<ComplexDouble>
     where T.S == Double {
     var result = TensorDenseBLAS<ComplexDouble>(shape: tensor.shape, initialValue: .zero)
-    for index in mixedScalarIndexCombinations(for: tensor.shape) {
-        result[index] = tensor[index] / scalar
+    for i in mixedScalarIndexCombinations(for: tensor.shape) {
+        result[i] = tensor[i] / scalar
     }
     return result
 }
 
 public func * <T: TensorArithmeticReference>(tensor: T, scalar: Double) -> T where T.S == ComplexDouble {
     var result = T(shape: tensor.shape, initialValue: .zero)
-    for index in mixedScalarIndexCombinations(for: tensor.shape) {
-        result[index] = tensor[index] * scalar
+    for i in mixedScalarIndexCombinations(for: tensor.shape) {
+        result[i] = tensor[i] * scalar
     }
     return result
 }
@@ -50,8 +50,8 @@ public func * <T: TensorArithmeticReference>(scalar: Double, tensor: T) -> T whe
 
 public func / <T: TensorArithmeticReference>(tensor: T, scalar: Double) -> T where T.S == ComplexDouble {
     var result = T(shape: tensor.shape, initialValue: .zero)
-    for index in mixedScalarIndexCombinations(for: tensor.shape) {
-        result[index] = tensor[index] / scalar
+    for i in mixedScalarIndexCombinations(for: tensor.shape) {
+        result[i] = tensor[i] / scalar
     }
     return result
 }
@@ -59,8 +59,8 @@ public func / <T: TensorArithmeticReference>(tensor: T, scalar: Double) -> T whe
 public func * <T: TensorArithmeticReference>(tensor: T, scalar: ComplexFloat) -> TensorDenseBLAS<ComplexFloat>
     where T.S == Float {
     var result = TensorDenseBLAS<ComplexFloat>(shape: tensor.shape, initialValue: .zero)
-    for index in mixedScalarIndexCombinations(for: tensor.shape) {
-        result[index] = tensor[index] * scalar
+    for i in mixedScalarIndexCombinations(for: tensor.shape) {
+        result[i] = tensor[i] * scalar
     }
     return result
 }
@@ -73,16 +73,16 @@ public func * <T: TensorArithmeticReference>(scalar: ComplexFloat, tensor: T) ->
 public func / <T: TensorArithmeticReference>(tensor: T, scalar: ComplexFloat) -> TensorDenseBLAS<ComplexFloat>
     where T.S == Float {
     var result = TensorDenseBLAS<ComplexFloat>(shape: tensor.shape, initialValue: .zero)
-    for index in mixedScalarIndexCombinations(for: tensor.shape) {
-        result[index] = tensor[index] / scalar
+    for i in mixedScalarIndexCombinations(for: tensor.shape) {
+        result[i] = tensor[i] / scalar
     }
     return result
 }
 
 public func * <T: TensorArithmeticReference>(tensor: T, scalar: Float) -> T where T.S == ComplexFloat {
     var result = T(shape: tensor.shape, initialValue: .zero)
-    for index in mixedScalarIndexCombinations(for: tensor.shape) {
-        result[index] = tensor[index] * scalar
+    for i in mixedScalarIndexCombinations(for: tensor.shape) {
+        result[i] = tensor[i] * scalar
     }
     return result
 }
@@ -93,8 +93,8 @@ public func * <T: TensorArithmeticReference>(scalar: Float, tensor: T) -> T wher
 
 public func / <T: TensorArithmeticReference>(tensor: T, scalar: Float) -> T where T.S == ComplexFloat {
     var result = T(shape: tensor.shape, initialValue: .zero)
-    for index in mixedScalarIndexCombinations(for: tensor.shape) {
-        result[index] = tensor[index] / scalar
+    for i in mixedScalarIndexCombinations(for: tensor.shape) {
+        result[i] = tensor[i] / scalar
     }
     return result
 }

--- a/Sources/Tensors/Protocols/TensorMultiplication.swift
+++ b/Sources/Tensors/Protocols/TensorMultiplication.swift
@@ -53,8 +53,8 @@ extension TensorMultiplication {
         for freeIndex in Self.indexCombinations(for: freeShape) {
             for contractIndex in Self.indexCombinations(for: contractShape) {
                 var tensorIndex = Array(repeating: 0, count: rank)
-                for (position, index) in freeIndices.enumerated() { tensorIndex[index] = freeIndex[position] }
-                for (position, index) in contractIndices.enumerated() { tensorIndex[index] = contractIndex[position] }
+                for (position, i) in freeIndices.enumerated() { tensorIndex[i] = freeIndex[position] }
+                for (position, i) in contractIndices.enumerated() { tensorIndex[i] = contractIndex[position] }
                 matrix[
                     Self.linearIndex(freeIndex, shape: freeShape),
                     Self.linearIndex(contractIndex, shape: contractShape)
@@ -82,8 +82,8 @@ extension TensorMultiplication {
         for contractIndex in Self.indexCombinations(for: contractShape) {
             for freeIndex in Self.indexCombinations(for: freeShape) {
                 var tensorIndex = Array(repeating: 0, count: rank)
-                for (position, index) in contractIndices.enumerated() { tensorIndex[index] = contractIndex[position] }
-                for (position, index) in freeIndices.enumerated() { tensorIndex[index] = freeIndex[position] }
+                for (position, i) in contractIndices.enumerated() { tensorIndex[i] = contractIndex[position] }
+                for (position, i) in freeIndices.enumerated() { tensorIndex[i] = freeIndex[position] }
                 matrix[
                     Self.linearIndex(contractIndex, shape: contractShape),
                     Self.linearIndex(freeIndex, shape: freeShape)
@@ -115,9 +115,9 @@ extension TensorMultiplication {
         return (0..<countElements(for: shape)).map { flatIndex in
             var remaining = flatIndex
             return shape.map { dimension in
-                let index = remaining % dimension
+                let i = remaining % dimension
                 remaining /= dimension
-                return index
+                return i
             }
         }
     }
@@ -125,8 +125,8 @@ extension TensorMultiplication {
     private static func linearIndex(_ indices: [Int], shape: [Int]) -> Int {
         var stride = 1
         var flatIndex = 0
-        for (index, dimension) in zip(indices, shape) {
-            flatIndex += index * stride
+        for (i, dimension) in zip(indices, shape) {
+            flatIndex += i * stride
             stride *= dimension
         }
         return flatIndex

--- a/Sources/Tensors/Protocols/TensorStructure.swift
+++ b/Sources/Tensors/Protocols/TensorStructure.swift
@@ -21,9 +21,9 @@ public enum TensorNestedArray<S: PluScalar>: Equatable {
         switch (self, indices.first) {
         case (.scalar(let value), nil):
             return value
-        case (.array(let subtensor), .some(let index)):
-            precondition(index >= 0 && index < subtensor.count, "Tensor index out of bounds")
-            return subtensor[index][Array(indices.dropFirst())]
+        case (.array(let subtensor), .some(let i)):
+            precondition(i >= 0 && i < subtensor.count, "Tensor index out of bounds")
+            return subtensor[i][Array(indices.dropFirst())]
         default:
             preconditionFailure("Tensor index rank must match tensor rank")
         }
@@ -40,9 +40,9 @@ public enum TensorNestedArray<S: PluScalar>: Equatable {
         return (0..<shape.reduce(1, *)).map { flatIndex in
             var remaining = flatIndex
             return shape.map { dimension in
-                let index = remaining % dimension
+                let i = remaining % dimension
                 remaining /= dimension
-                return index
+                return i
             }
         }
     }

--- a/Sources/Tensors/Storage/TensorFlatView.swift
+++ b/Sources/Tensors/Storage/TensorFlatView.swift
@@ -4,7 +4,7 @@ public struct TensorFlatView<Scalar: PluScalar>: Equatable {
     public var shape: [Int]
     public var strides: [Int]
 
-    public init(storage: TensorStorage<Scalar>, offset: Int, shape: [Int], strides: [Int]) {
+public init(storage: TensorStorage<Scalar>, offset: Int, shape: [Int], strides: [Int]) {
         precondition(offset >= 0, "Tensor view offset must be non-negative")
         precondition(shape.allSatisfy { $0 >= 0 }, "Tensor shape dimensions must be non-negative")
         precondition(shape.count == strides.count, "Tensor shape and strides must have the same rank")

--- a/Sources/Tensors/Storage/TensorFlatView.swift
+++ b/Sources/Tensors/Storage/TensorFlatView.swift
@@ -97,12 +97,12 @@ extension TensorFlatView {
         var newShape: [Int] = []
         var newStrides: [Int] = []
 
-        for (dimension, index) in indices.enumerated() {
-            switch index {
+        for (dimension, i) in indices.enumerated() {
+            switch i {
             case .index:
-                newOffset += index.fixedIndex(dimensionSize: shape[dimension]) * strides[dimension]
+                newOffset += i.fixedIndex(dimensionSize: shape[dimension]) * strides[dimension]
             case .range, .step, .all:
-                let range = index.sliceRange(dimensionSize: shape[dimension])
+                let range = i.sliceRange(dimensionSize: shape[dimension])
                 validate(range: range, dimension: dimension)
                 newOffset += range.start * strides[dimension]
                 newShape.append(range.length)
@@ -163,10 +163,10 @@ extension TensorFlatView {
         storage.elements[offset + index0 * strides[0] + index1 * strides[1]]
     }
 
-    func storageIndex(forUncheckedIndex index: [Int]) -> Int {
+    func storageIndex(forUncheckedIndex indices: [Int]) -> Int {
         var linearIndex = offset
         for dimension in 0..<rank {
-            linearIndex += index[dimension] * strides[dimension]
+            linearIndex += indices[dimension] * strides[dimension]
         }
         return linearIndex
     }
@@ -198,8 +198,8 @@ extension TensorFlatView {
     private func linearIndex(_ indices: [Int]) -> Int {
         precondition(indices.count == rank, "Tensor index rank \(indices.count) does not match tensor rank \(rank)")
 
-        for (dimension, index) in indices.enumerated() {
-            precondition(index >= 0 && index < shape[dimension], "Tensor index out of bounds")
+        for (dimension, i) in indices.enumerated() {
+            precondition(i >= 0 && i < shape[dimension], "Tensor index out of bounds")
         }
 
         return offset + zip(indices, strides).map(*).reduce(0, +)
@@ -215,10 +215,10 @@ extension TensorFlatView {
     private func flattenedElements() -> [Scalar] {
         var elements: [Scalar] = []
         elements.reserveCapacity(count)
-        var index = Array(repeating: 0, count: rank)
+        var i = Array(repeating: 0, count: rank)
         for _ in 0..<count {
-            elements.append(storage.elements[storageIndex(forUncheckedIndex: index)])
-            Self.increment(&index, shape: shape)
+            elements.append(storage.elements[storageIndex(forUncheckedIndex: i)])
+            Self.increment(&i, shape: shape)
         }
         return elements
     }
@@ -233,11 +233,11 @@ extension TensorFlatView {
             assignRankTwo(replacement, to: destination)
             return
         }
-        var index = Array(repeating: 0, count: destination.rank)
+        var i = Array(repeating: 0, count: destination.rank)
         for _ in 0..<destination.count {
-            let element = replacement.storage.elements[replacement.storageIndex(forUncheckedIndex: index)]
-            storage[destination.storageIndex(forUncheckedIndex: index)] = element
-            Self.increment(&index, shape: destination.shape)
+            let element = replacement.storage.elements[replacement.storageIndex(forUncheckedIndex: i)]
+            storage[destination.storageIndex(forUncheckedIndex: i)] = element
+            Self.increment(&i, shape: destination.shape)
         }
     }
 
@@ -246,12 +246,12 @@ extension TensorFlatView {
             assignRankTwoColumnSegments(replacement, to: destination)
             return
         }
-        for index1 in 0..<destination.shape[1] {
-            let destinationColumn = destination.offset + index1 * destination.strides[1]
-            let replacementColumn = replacement.offset + index1 * replacement.strides[1]
-            for index0 in 0..<destination.shape[0] {
-                storage[destinationColumn + index0 * destination.strides[0]] =
-                    replacement.storage.elements[replacementColumn + index0 * replacement.strides[0]]
+        for j in 0..<destination.shape[1] {
+            let destinationColumn = destination.offset + j * destination.strides[1]
+            let replacementColumn = replacement.offset + j * replacement.strides[1]
+            for i in 0..<destination.shape[0] {
+                storage[destinationColumn + i * destination.strides[0]] =
+                    replacement.storage.elements[replacementColumn + i * replacement.strides[0]]
             }
         }
     }
@@ -260,9 +260,9 @@ extension TensorFlatView {
                                                       to destination: TensorFlatView<Scalar>) {
         storage.elements.withUnsafeMutableBufferPointer { destinationElements in
             replacement.storage.elements.withUnsafeBufferPointer { replacementElements in
-                for index1 in 0..<destination.shape[1] {
-                    let destinationColumn = destination.offset + index1 * destination.strides[1]
-                    let replacementColumn = replacement.offset + index1 * replacement.strides[1]
+                for j in 0..<destination.shape[1] {
+                    let destinationColumn = destination.offset + j * destination.strides[1]
+                    let replacementColumn = replacement.offset + j * replacement.strides[1]
                     var destinationIndex = destinationColumn
                     var replacementIndex = replacementColumn
                     for _ in 0..<destination.shape[0] {
@@ -275,11 +275,11 @@ extension TensorFlatView {
         }
     }
 
-    private static func increment(_ index: inout [Int], shape: [Int]) {
+    private static func increment(_ i: inout [Int], shape: [Int]) {
         for dimension in 0..<shape.count {
-            index[dimension] += 1
-            if index[dimension] < shape[dimension] { return }
-            index[dimension] = 0
+            i[dimension] += 1
+            if i[dimension] < shape[dimension] { return }
+            i[dimension] = 0
         }
     }
 

--- a/Sources/Tensors/Storage/TensorStorage.swift
+++ b/Sources/Tensors/Storage/TensorStorage.swift
@@ -5,8 +5,8 @@ public final class TensorStorage<Scalar: PluScalar> {
         self.elements = elements
     }
 
-    public subscript(index: Int) -> Scalar {
-        get { elements[index] }
-        set { elements[index] = newValue }
+    public subscript(i: Int) -> Scalar {
+        get { elements[i] }
+        set { elements[i] = newValue }
     }
 }

--- a/Sources/Tensors/Tensor/LazyTensor.swift
+++ b/Sources/Tensors/Tensor/LazyTensor.swift
@@ -32,10 +32,10 @@ struct LazyTensor<S: PluScalar> {
         LazyTensor(terms: terms.map { Term(coefficient: scalar * $0.coefficient, view: $0.view) })
     }
 
-    func value(_ index: [Int]) -> S {
+    func value(_ i: [Int]) -> S {
         var result = S.zero
         for term in terms {
-            result += term.coefficient * term.view.storage.elements[term.view.storageIndex(forUncheckedIndex: index)]
+            result += term.coefficient * term.view.storage.elements[term.view.storageIndex(forUncheckedIndex: i)]
         }
         return result
     }
@@ -44,28 +44,28 @@ struct LazyTensor<S: PluScalar> {
         var elements: [S] = []
         let count = shape.reduce(1, *)
         elements.reserveCapacity(count)
-        var index = Array(repeating: 0, count: shape.count)
+        var i = Array(repeating: 0, count: shape.count)
         for _ in 0..<count {
-            elements.append(value(index))
-            Self.increment(&index, shape: shape)
+            elements.append(value(i))
+            Self.increment(&i, shape: shape)
         }
         return elements
     }
 
     func assign(to destination: inout TensorFlatView<S>) {
         precondition(destination.shape == shape, "Assigned slice shape \(shape) must match destination slice shape")
-        var index = Array(repeating: 0, count: shape.count)
+        var i = Array(repeating: 0, count: shape.count)
         for _ in 0..<shape.reduce(1, *) {
-            destination.storage.elements[destination.storageIndex(forUncheckedIndex: index)] = value(index)
-            Self.increment(&index, shape: shape)
+            destination.storage.elements[destination.storageIndex(forUncheckedIndex: i)] = value(i)
+            Self.increment(&i, shape: shape)
         }
     }
 
-    private static func increment(_ index: inout [Int], shape: [Int]) {
+    private static func increment(_ i: inout [Int], shape: [Int]) {
         for dimension in 0..<shape.count {
-            index[dimension] += 1
-            if index[dimension] < shape[dimension] { return }
-            index[dimension] = 0
+            i[dimension] += 1
+            if i[dimension] < shape[dimension] { return }
+            i[dimension] = 0
         }
     }
 }

--- a/Sources/Tensors/Tensor/TensorDenseBLAS.swift
+++ b/Sources/Tensors/Tensor/TensorDenseBLAS.swift
@@ -174,13 +174,13 @@ extension TensorDenseBLAS {
         var rightFreeIndices: [Int] = []
         var leftFreeShape: [Int] = []
         var rightFreeShape: [Int] = []
-        for index in 0..<rank where !leftContracted[index] {
-            leftFreeIndices.append(index)
-            leftFreeShape.append(shape[index])
+        for i in 0..<rank where !leftContracted[i] {
+            leftFreeIndices.append(i)
+            leftFreeShape.append(shape[i])
         }
-        for index in 0..<other.rank where !rightContracted[index] {
-            rightFreeIndices.append(index)
-            rightFreeShape.append(other.shape[index])
+        for i in 0..<other.rank where !rightContracted[i] {
+            rightFreeIndices.append(i)
+            rightFreeShape.append(other.shape[i])
         }
         return TensorDenseContractionPlan(
             leftFreeIndices: leftFreeIndices,
@@ -635,8 +635,8 @@ extension TensorDenseBLAS {
         for freeIndex in indexCombinations(for: freeShape) {
             for contractIndex in indexCombinations(for: contractShape) {
                 var tensorIndex = Array(repeating: 0, count: rank)
-                for (position, index) in freeIndices.enumerated() { tensorIndex[index] = freeIndex[position] }
-                for (position, index) in contractIndices.enumerated() { tensorIndex[index] = contractIndex[position] }
+                for (position, i) in freeIndices.enumerated() { tensorIndex[i] = freeIndex[position] }
+                for (position, i) in contractIndices.enumerated() { tensorIndex[i] = contractIndex[position] }
                 matrix[linearIndex(freeIndex, shape: freeShape), linearIndex(contractIndex, shape: contractShape)] =
                     self[tensorIndex]
             }
@@ -655,8 +655,8 @@ extension TensorDenseBLAS {
         for contractIndex in indexCombinations(for: contractShape) {
             for freeIndex in indexCombinations(for: freeShape) {
                 var tensorIndex = Array(repeating: 0, count: rank)
-                for (position, index) in contractIndices.enumerated() { tensorIndex[index] = contractIndex[position] }
-                for (position, index) in freeIndices.enumerated() { tensorIndex[index] = freeIndex[position] }
+                for (position, i) in contractIndices.enumerated() { tensorIndex[i] = contractIndex[position] }
+                for (position, i) in freeIndices.enumerated() { tensorIndex[i] = freeIndex[position] }
                 matrix[linearIndex(contractIndex, shape: contractShape), linearIndex(freeIndex, shape: freeShape)] =
                     self[tensorIndex]
             }
@@ -670,9 +670,9 @@ extension TensorDenseBLAS {
         return (0..<countElements(for: shape)).map { flatIndex in
             var remaining = flatIndex
             return shape.map { dimension in
-                let index = remaining % dimension
+                let i = remaining % dimension
                 remaining /= dimension
-                return index
+                return i
             }
         }
     }
@@ -680,8 +680,8 @@ extension TensorDenseBLAS {
     private func linearIndex(_ indices: [Int], shape: [Int]) -> Int {
         var stride = 1
         var flatIndex = 0
-        for (index, dimension) in zip(indices, shape) {
-            flatIndex += index * stride
+        for (i, dimension) in zip(indices, shape) {
+            flatIndex += i * stride
             stride *= dimension
         }
         return flatIndex
@@ -691,12 +691,12 @@ extension TensorDenseBLAS {
 
     private func areStorageOrdered(_ first: [Int], _ second: [Int], rank: Int) -> Bool {
         var expected = 0
-        for index in first {
-            if index != expected { return false }
+        for i in first {
+            if i != expected { return false }
             expected += 1
         }
-        for index in second {
-            if index != expected { return false }
+        for i in second {
+            if i != expected { return false }
             expected += 1
         }
         return expected == rank
@@ -713,7 +713,7 @@ private func doubleSum(_ left: [Double], _ right: [Double]) -> [Double] {
     Array<Double>(unsafeUninitializedCapacity: left.count) { result, initializedCount in
         left.withUnsafeBufferPointer { left in
             right.withUnsafeBufferPointer { right in
-                for index in 0..<left.count { result[index] = left[index] + right[index] }
+                for i in 0..<left.count { result[i] = left[i] + right[i] }
             }
         }
         initializedCount = left.count
@@ -724,7 +724,7 @@ private func floatSum(_ left: [Float], _ right: [Float]) -> [Float] {
     Array<Float>(unsafeUninitializedCapacity: left.count) { result, initializedCount in
         left.withUnsafeBufferPointer { left in
             right.withUnsafeBufferPointer { right in
-                for index in 0..<left.count { result[index] = left[index] + right[index] }
+                for i in 0..<left.count { result[i] = left[i] + right[i] }
             }
         }
         initializedCount = left.count
@@ -735,7 +735,7 @@ private func doubleDifference(_ left: [Double], _ right: [Double]) -> [Double] {
     Array<Double>(unsafeUninitializedCapacity: left.count) { result, initializedCount in
         left.withUnsafeBufferPointer { left in
             right.withUnsafeBufferPointer { right in
-                for index in 0..<left.count { result[index] = left[index] - right[index] }
+                for i in 0..<left.count { result[i] = left[i] - right[i] }
             }
         }
         initializedCount = left.count
@@ -746,7 +746,7 @@ private func floatDifference(_ left: [Float], _ right: [Float]) -> [Float] {
     Array<Float>(unsafeUninitializedCapacity: left.count) { result, initializedCount in
         left.withUnsafeBufferPointer { left in
             right.withUnsafeBufferPointer { right in
-                for index in 0..<left.count { result[index] = left[index] - right[index] }
+                for i in 0..<left.count { result[i] = left[i] - right[i] }
             }
         }
         initializedCount = left.count
@@ -756,7 +756,7 @@ private func floatDifference(_ left: [Float], _ right: [Float]) -> [Float] {
 private func doubleScale(_ values: [Double], by scalar: Double) -> [Double] {
     Array<Double>(unsafeUninitializedCapacity: values.count) { result, initializedCount in
         values.withUnsafeBufferPointer { values in
-            for index in 0..<values.count { result[index] = values[index] * scalar }
+            for i in 0..<values.count { result[i] = values[i] * scalar }
         }
         initializedCount = values.count
     }
@@ -765,7 +765,7 @@ private func doubleScale(_ values: [Double], by scalar: Double) -> [Double] {
 private func floatScale(_ values: [Float], by scalar: Float) -> [Float] {
     Array<Float>(unsafeUninitializedCapacity: values.count) { result, initializedCount in
         values.withUnsafeBufferPointer { values in
-            for index in 0..<values.count { result[index] = values[index] * scalar }
+            for i in 0..<values.count { result[i] = values[i] * scalar }
         }
         initializedCount = values.count
     }
@@ -773,12 +773,12 @@ private func floatScale(_ values: [Float], by scalar: Float) -> [Float] {
 
 private func complexDoubleScale(_ values: [ComplexDouble], by scalar: ComplexDouble) -> [ComplexDouble] {
     var result = Array(repeating: ComplexDouble.zero, count: values.count)
-    for index in 0..<values.count { result[index] = values[index] * scalar }
+    for i in 0..<values.count { result[i] = values[i] * scalar }
     return result
 }
 
 private func complexFloatScale(_ values: [ComplexFloat], by scalar: ComplexFloat) -> [ComplexFloat] {
     var result = Array(repeating: ComplexFloat.zero, count: values.count)
-    for index in 0..<values.count { result[index] = values[index] * scalar }
+    for i in 0..<values.count { result[i] = values[i] * scalar }
     return result
 }

--- a/Sources/Tensors/Tensor/TensorDenseReference.swift
+++ b/Sources/Tensors/Tensor/TensorDenseReference.swift
@@ -26,8 +26,8 @@ extension TensorDenseReference: TensorStructure {
         precondition(count == elements.count,
                      "Tensor shape \(shape) requires \(count) elements, but got \(elements.count)")
         self.init(shape: shape, initialValue: .zero)
-        for (index, element) in zip(Self.indexCombinations(for: shape), elements) {
-            self[index] = element
+        for (i, element) in zip(Self.indexCombinations(for: shape), elements) {
+            self[i] = element
         }
     }
 }
@@ -70,8 +70,8 @@ extension TensorDenseReference {
         get {
             let mapping = Self.sliceMapping(indices, shape: shape)
             var result = TensorDenseReference(shape: mapping.shape, initialValue: .zero)
-            for index in Self.indexCombinations(for: mapping.shape) {
-                result[index] = self[mapping.sourceIndex(index)]
+            for i in Self.indexCombinations(for: mapping.shape) {
+                result[i] = self[mapping.sourceIndex(i)]
             }
             return result
         }
@@ -81,8 +81,8 @@ extension TensorDenseReference {
             if let error {
                 preconditionFailure(error)
             }
-            for index in Self.indexCombinations(for: mapping.shape) {
-                self[mapping.sourceIndex(index)] = newValue[index]
+            for i in Self.indexCombinations(for: mapping.shape) {
+                self[mapping.sourceIndex(i)] = newValue[i]
             }
         }
     }
@@ -103,7 +103,7 @@ extension TensorDenseReference {
     }
 
     private static func value(in storage: TensorNestedArray<S>, at indices: [Int]) -> S {
-        guard let index = indices.first else {
+        guard let i = indices.first else {
             guard case .scalar(let value) = storage else {
                 preconditionFailure("Tensor index rank must match tensor rank")
             }
@@ -112,20 +112,20 @@ extension TensorDenseReference {
         guard case .array(let subtensors) = storage else {
             preconditionFailure("Tensor index rank must match tensor rank")
         }
-        precondition(index >= 0 && index < subtensors.count, "Tensor index out of bounds")
-        return value(in: subtensors[index], at: Array(indices.dropFirst()))
+        precondition(i >= 0 && i < subtensors.count, "Tensor index out of bounds")
+        return value(in: subtensors[i], at: Array(indices.dropFirst()))
     }
 
     private static func setValue(_ value: S, in storage: inout TensorNestedArray<S>, at indices: [Int]) {
-        guard let index = indices.first else {
+        guard let i = indices.first else {
             storage = .scalar(value)
             return
         }
         guard case .array(var subtensors) = storage else {
             preconditionFailure("Tensor index rank must match tensor rank")
         }
-        precondition(index >= 0 && index < subtensors.count, "Tensor index out of bounds")
-        setValue(value, in: &subtensors[index], at: Array(indices.dropFirst()))
+        precondition(i >= 0 && i < subtensors.count, "Tensor index out of bounds")
+        setValue(value, in: &subtensors[i], at: Array(indices.dropFirst()))
         storage = .array(subtensors)
     }
 
@@ -135,9 +135,9 @@ extension TensorDenseReference {
         return (0..<shape.reduce(1, *)).map { flatIndex in
             var remaining = flatIndex
             return shape.map { dimension in
-                let index = remaining % dimension
+                let i = remaining % dimension
                 remaining /= dimension
-                return index
+                return i
             }
         }
     }
@@ -149,12 +149,12 @@ extension TensorDenseReference {
         precondition(indices.count == shape.count, "Slice rank must match tensor rank")
         var resultShape: [Int] = []
         var dimensions: [(fixed: Int?, range: SliceRange?)] = []
-        for (dimension, index) in indices.enumerated() {
-            switch index {
+        for (dimension, i) in indices.enumerated() {
+            switch i {
             case .index:
-                dimensions.append((index.fixedIndex(dimensionSize: shape[dimension]), nil))
+                dimensions.append((i.fixedIndex(dimensionSize: shape[dimension]), nil))
             case .range, .step, .all:
-                let range = index.sliceRange(dimensionSize: shape[dimension])
+                let range = i.sliceRange(dimensionSize: shape[dimension])
                 let lastIndex = range.start + (range.length - 1) * range.step
                 precondition(range.start <= shape[dimension], "Slice start is out of bounds")
                 precondition(range.length == 0 || lastIndex < shape[dimension], "Slice end is out of bounds")

--- a/Sources/Tensors/TensorBases.swift
+++ b/Sources/Tensors/TensorBases.swift
@@ -13,9 +13,9 @@ public struct VectorBase<Implementation: PluVector>: TensorArithmeticReference {
 extension VectorBase: PluVector {
     public var size: Int { implementation.size }
 
-    public subscript(index: Int) -> Implementation.S {
-        get { implementation[index] }
-        set { implementation[index] = newValue }
+    public subscript(i: Int) -> Implementation.S {
+        get { implementation[i] }
+        set { implementation[i] = newValue }
     }
 
     public subscript(_ indices: [Int]) -> Implementation.S {

--- a/Sources/Tensors/Vector/VectorDenseBLAS.swift
+++ b/Sources/Tensors/Vector/VectorDenseBLAS.swift
@@ -119,9 +119,9 @@ extension VectorDenseBLAS {
         set { assign(newValue, to: [TensorSliceIndex.range(range)]) }
     }
 
-    public subscript(index: TensorSliceIndex) -> VectorDenseBLAS<S> {
-        get { VectorDenseBLAS(view: materializedView().slice(index.sliceRange(dimensionSize: size))) }
-        set { assign(newValue, to: [index]) }
+    public subscript(i: TensorSliceIndex) -> VectorDenseBLAS<S> {
+        get { VectorDenseBLAS(view: materializedView().slice(i.sliceRange(dimensionSize: size))) }
+        set { assign(newValue, to: [i]) }
     }
 
     private func materializedView() -> TensorFlatView<S> {
@@ -489,7 +489,7 @@ private func doubleSum(_ left: [Double], _ right: [Double]) -> [Double] {
     Array<Double>(unsafeUninitializedCapacity: left.count) { result, initializedCount in
         left.withUnsafeBufferPointer { left in
             right.withUnsafeBufferPointer { right in
-                for index in 0..<left.count { result[index] = left[index] + right[index] }
+                for i in 0..<left.count { result[i] = left[i] + right[i] }
             }
         }
         initializedCount = left.count
@@ -500,7 +500,7 @@ private func floatSum(_ left: [Float], _ right: [Float]) -> [Float] {
     Array<Float>(unsafeUninitializedCapacity: left.count) { result, initializedCount in
         left.withUnsafeBufferPointer { left in
             right.withUnsafeBufferPointer { right in
-                for index in 0..<left.count { result[index] = left[index] + right[index] }
+                for i in 0..<left.count { result[i] = left[i] + right[i] }
             }
         }
         initializedCount = left.count
@@ -511,7 +511,7 @@ private func doubleDifference(_ left: [Double], _ right: [Double]) -> [Double] {
     Array<Double>(unsafeUninitializedCapacity: left.count) { result, initializedCount in
         left.withUnsafeBufferPointer { left in
             right.withUnsafeBufferPointer { right in
-                for index in 0..<left.count { result[index] = left[index] - right[index] }
+                for i in 0..<left.count { result[i] = left[i] - right[i] }
             }
         }
         initializedCount = left.count
@@ -522,7 +522,7 @@ private func floatDifference(_ left: [Float], _ right: [Float]) -> [Float] {
     Array<Float>(unsafeUninitializedCapacity: left.count) { result, initializedCount in
         left.withUnsafeBufferPointer { left in
             right.withUnsafeBufferPointer { right in
-                for index in 0..<left.count { result[index] = left[index] - right[index] }
+                for i in 0..<left.count { result[i] = left[i] - right[i] }
             }
         }
         initializedCount = left.count
@@ -532,7 +532,7 @@ private func floatDifference(_ left: [Float], _ right: [Float]) -> [Float] {
 private func doubleScale(_ values: [Double], by scalar: Double) -> [Double] {
     Array<Double>(unsafeUninitializedCapacity: values.count) { result, initializedCount in
         values.withUnsafeBufferPointer { values in
-            for index in 0..<values.count { result[index] = values[index] * scalar }
+            for i in 0..<values.count { result[i] = values[i] * scalar }
         }
         initializedCount = values.count
     }
@@ -541,7 +541,7 @@ private func doubleScale(_ values: [Double], by scalar: Double) -> [Double] {
 private func floatScale(_ values: [Float], by scalar: Float) -> [Float] {
     Array<Float>(unsafeUninitializedCapacity: values.count) { result, initializedCount in
         values.withUnsafeBufferPointer { values in
-            for index in 0..<values.count { result[index] = values[index] * scalar }
+            for i in 0..<values.count { result[i] = values[i] * scalar }
         }
         initializedCount = values.count
     }
@@ -549,12 +549,12 @@ private func floatScale(_ values: [Float], by scalar: Float) -> [Float] {
 
 private func complexDoubleScale(_ values: [ComplexDouble], by scalar: ComplexDouble) -> [ComplexDouble] {
     var result = Array(repeating: ComplexDouble.zero, count: values.count)
-    for index in 0..<values.count { result[index] = values[index] * scalar }
+    for i in 0..<values.count { result[i] = values[i] * scalar }
     return result
 }
 
 private func complexFloatScale(_ values: [ComplexFloat], by scalar: ComplexFloat) -> [ComplexFloat] {
     var result = Array(repeating: ComplexFloat.zero, count: values.count)
-    for index in 0..<values.count { result[index] = values[index] * scalar }
+    for i in 0..<values.count { result[i] = values[i] * scalar }
     return result
 }

--- a/Sources/Tensors/Vector/VectorFlatView.swift
+++ b/Sources/Tensors/Vector/VectorFlatView.swift
@@ -40,17 +40,17 @@ extension VectorFlatView: VectorView {
         }
     }
 
-    public subscript(index: Int) -> Scalar {
-        get { view[[index]] }
-        set { view[[index]] = newValue }
+    public subscript(i: Int) -> Scalar {
+        get { view[[i]] }
+        set { view[[i]] = newValue }
     }
 
     public subscript(range: Range<Int>) -> VectorFlatView<Scalar> {
         slice(SliceRange(range))
     }
 
-    public subscript(index: TensorSliceIndex) -> VectorFlatView<Scalar> {
-        slice(index.sliceRange(dimensionSize: size))
+    public subscript(i: TensorSliceIndex) -> VectorFlatView<Scalar> {
+        slice(i.sliceRange(dimensionSize: size))
     }
 
     public func slice(_ range: SliceRange) -> VectorFlatView<Scalar> {

--- a/Sources/Tensors/Vector/VectorView.swift
+++ b/Sources/Tensors/Vector/VectorView.swift
@@ -1,5 +1,5 @@
 public protocol VectorView: TensorView {
     var size: Int { get }
 
-    subscript(index: Int) -> Scalar { get set }
+    subscript(i: Int) -> Scalar { get set }
 }

--- a/Tests/LinearSolversTests/DenseLinearSolverTests.swift
+++ b/Tests/LinearSolversTests/DenseLinearSolverTests.swift
@@ -69,11 +69,11 @@ func solveLinearDense_correctness_smallMatrices<MatrixType: PluMatrix>(matrixTyp
     let expected = VectorDenseBLAS<Float>([1.0, 2.0, 3.0])
     let actual = solveLinearDense(A, b)
 
-    #expect(actual.isApproximatelyEqual(to: expected, relativeTolerance: 1e-5))
+    #expect(actual.isClose(to: expected, relativeTolerance: 1e-5))
 
     #if canImport(Accelerate)
     let accelerate = solveLinearDense(A, b, blasImplementation: .accelerate)
-    #expect(accelerate.isApproximatelyEqual(to: expected, relativeTolerance: 1e-5))
+    #expect(accelerate.isClose(to: expected, relativeTolerance: 1e-5))
     #endif
 }
 
@@ -99,11 +99,11 @@ func solveLinearDense_correctness_smallMatrices<MatrixType: PluMatrix>(matrixTyp
     let expected = VectorDenseBLAS<ComplexFloat>([ComplexFloat(1.0, 1.0), ComplexFloat(2.0, -1.0)])
     let actual = solveLinearDense(A, b)
 
-    #expect(actual.isApproximatelyEqual(to: expected, relativeTolerance: 1e-5))
+    #expect(actual.isClose(to: expected, relativeTolerance: 1e-5))
 
     #if canImport(Accelerate)
     let accelerate = solveLinearDense(A, b, blasImplementation: .accelerate)
-    #expect(accelerate.isApproximatelyEqual(to: expected, relativeTolerance: 1e-5))
+    #expect(accelerate.isClose(to: expected, relativeTolerance: 1e-5))
     #endif
 }
 

--- a/Tests/LinearSolversTests/DenseLinearSolverTests.swift
+++ b/Tests/LinearSolversTests/DenseLinearSolverTests.swift
@@ -15,7 +15,7 @@ import Tensors
     let v_actual = solveLinearDense(A, b)
     let v_expected = VectorDenseReference([1.0, 2, 3])
 
-    #expect(v_actual.isApproximatelyEqual(to: v_expected))
+    #expect(v_actual.isClose(to: v_expected))
 }
 
 @Test func solveLinearDenseReference_exampleUsage() throws {
@@ -24,7 +24,7 @@ import Tensors
     let actual = solveLinearDenseReference(A, b)
     let expected = VectorDenseReference([1.0, 2, 3])
 
-    #expect(actual.isApproximatelyEqual(to: expected))
+    #expect(actual.isClose(to: expected))
 }
 
 func solveLinearDense_correctness_smallMatrices<MatrixType: PluMatrix>(matrixType: MatrixType.Type) where MatrixType.S == Double {
@@ -34,7 +34,7 @@ func solveLinearDense_correctness_smallMatrices<MatrixType: PluMatrix>(matrixTyp
         let b = makeVector(size: n)
         let v = solveLinearDense(A, b)
 
-        #expect((A * v).isApproximatelyEqual(to: b, relativeTolerance: 1e-12))
+        #expect((A * v).isClose(to: b, relativeTolerance: 1e-12))
     }
 }
 
@@ -46,8 +46,8 @@ func solveLinearDense_correctness_smallMatrices<MatrixType: PluMatrix>(matrixTyp
     let b3 = VectorDenseReference([3.0, 2, -9])
     let x3 = VectorDenseReference([1.0, 2, 3])
 
-    #expect(solveLinearDenseReference(A2, b2).isApproximatelyEqual(to: x2))
-    #expect(solveLinearDenseReference(A3, b3).isApproximatelyEqual(to: x3))
+    #expect(solveLinearDenseReference(A2, b2).isClose(to: x2))
+    #expect(solveLinearDenseReference(A3, b3).isClose(to: x3))
 }
 
 @Test func solveLinearDenseReference_pivotsRows() {
@@ -55,7 +55,7 @@ func solveLinearDense_correctness_smallMatrices<MatrixType: PluMatrix>(matrixTyp
     let b = VectorDenseReference([-2.0, 2.0])
     let expected = VectorDenseReference([3.0, -1.0])
 
-    #expect(solveLinearDenseReference(A, b).isApproximatelyEqual(to: expected))
+    #expect(solveLinearDenseReference(A, b).isClose(to: expected))
 }
 
 @Test func solveLinearDense_correctness_smallMatrices_BLAS() {
@@ -70,11 +70,11 @@ func solveLinearDense_correctness_smallMatrices<MatrixType: PluMatrix>(matrixTyp
     let expected = VectorDenseReference<ComplexDouble>([ComplexDouble(1.0, 1.0), ComplexDouble(2.0, -1.0)])
     let actual = solveLinearDense(A, b)
 
-    #expect(actual.isApproximatelyEqual(to: expected, relativeTolerance: 1e-12))
+    #expect(actual.isClose(to: expected, relativeTolerance: 1e-12))
 
     #if canImport(Accelerate)
     let accelerate = solveLinearDense(A, b, blasImplementation: .accelerate)
-    #expect(accelerate.isApproximatelyEqual(to: expected, relativeTolerance: 1e-12))
+    #expect(accelerate.isClose(to: expected, relativeTolerance: 1e-12))
     #endif
 }
 
@@ -85,7 +85,7 @@ func solveLinearDense_correctness_smallMatrices<MatrixType: PluMatrix>(matrixTyp
     let expected = VectorDenseReference<ComplexDouble>([ComplexDouble(1.0, 1.0), ComplexDouble(2.0, -1.0)])
     let actual = solveLinearDenseReference(A, b)
 
-    #expect(actual.isApproximatelyEqual(to: expected, relativeTolerance: 1e-12))
+    #expect(actual.isClose(to: expected, relativeTolerance: 1e-12))
 }
 
 func solveLinearDenseBLAS_correctness_largeMatrices() {
@@ -95,7 +95,7 @@ func solveLinearDenseBLAS_correctness_largeMatrices() {
         let b = makeVector(size: n)
         let v = solveLinearDense(A, b)
 
-        #expect((A * v).isApproximatelyEqual(to: b, relativeTolerance: 1e-8))
+        #expect((A * v).isClose(to: b, relativeTolerance: 1e-8))
     }
 }
 

--- a/Tests/TensorsTests/ComplexFloatTests.swift
+++ b/Tests/TensorsTests/ComplexFloatTests.swift
@@ -8,7 +8,7 @@ import Testing
     #expect(value.round(precision: 2) == ComplexFloat(1.23, -2.35))
     #expect(ComplexFloat.i == ComplexFloat(0.0, 1.0))
     #expect(ComplexFloat(1.0, 2.0).star == ComplexFloat(1.0, -2.0))
-    #expect(ComplexFloat(3.0, 4.0).mod.isApproximatelyEqual(to: 5.0, relativeTolerance: 1e-6))
+    #expect(ComplexFloat(3.0, 4.0).mod.isClose(to: 5.0, relativeTolerance: 1e-6))
     #expect((Float(2.0) + ComplexFloat(1.0, -3.0)) == ComplexFloat(3.0, -3.0))
 }
 
@@ -36,7 +36,7 @@ private func checkComplexFloatVector<V: PluVector>(_ type: V.Type) where V.S == 
     let u = V([ComplexFloat(3.0, 4.0), ComplexFloat(0.0, 12.0)])
     let v = V([ComplexFloat(1.0, -1.0), ComplexFloat(2.0, 0.0)])
 
-    #expect(u.magnitude().isApproximatelyEqual(to: 13.0, relativeTolerance: 1e-6))
+    #expect(u.magnitude().isClose(to: 13.0, relativeTolerance: 1e-6))
     #expect((u + v).toArray() == [ComplexFloat(4.0, 3.0), ComplexFloat(2.0, 12.0)])
     #expect((u * ComplexFloat(0.0, 1.0)).toArray() == [ComplexFloat(-4.0, 3.0), ComplexFloat(-12.0, 0.0)])
     #expect((u / ComplexFloat(2.0, 0.0)).toArray() == [ComplexFloat(1.5, 2.0), ComplexFloat(0.0, 6.0)])

--- a/Tests/TensorsTests/FloatTests.swift
+++ b/Tests/TensorsTests/FloatTests.swift
@@ -5,7 +5,7 @@ import Testing
     let value: Float = 1.23456
 
     #expect(value.round(precision: 2) == 1.23)
-    #expect((value / 2.0).isApproximatelyEqual(to: 0.61728, relativeTolerance: 1e-6))
+    #expect((value / 2.0).isClose(to: 0.61728, relativeTolerance: 1e-6))
 }
 
 @Test func Float_vectorReferenceAndBLASOperations() {
@@ -27,7 +27,7 @@ private func checkFloatVector<V: PluVector>(_ type: V.Type) where V.S == Float {
     let u = V([3.0, 4.0, 12.0])
     let v = V([2.0, -1.0, 3.0])
 
-    #expect(u.magnitude().isApproximatelyEqual(to: 13.0, relativeTolerance: 1e-6))
+    #expect(u.magnitude().isClose(to: 13.0, relativeTolerance: 1e-6))
     #expect(u.dot(v) == 38.0)
     #expect((u + v).toArray() == [5.0, 3.0, 15.0])
     #expect((u * 2.0).toArray() == [6.0, 8.0, 24.0])

--- a/Tests/TensorsTests/MatrixDenseBLASTests.swift
+++ b/Tests/TensorsTests/MatrixDenseBLASTests.swift
@@ -49,6 +49,30 @@ import Testing
     #expect(result.toArray() == [[10.0, 10.0], [10.0, 10.0]])
 }
 
+@Test func MatrixDense_BLAS_lazyDuplicateTermsCancelOnMaterialization() {
+    let a = MatrixDenseBLAS<Double>([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]])
+    let b = MatrixDenseBLAS<Double>([[9.0, 8.0, 7.0], [6.0, 5.0, 4.0], [3.0, 2.0, 1.0]])
+    let aSlice = a[1..<3, 1..<3]
+    let bSlice = b[1..<3, 1..<3]
+    let result = aSlice + bSlice - bSlice
+
+    #expect(result.lazy != nil)
+    if let lazy = result.lazy {
+        #expect(LazyMatrix<Double>.normalized(lazy.terms).count == 1)
+    }
+    #expect(result.toArray() == aSlice.toArray())
+}
+
+@Test func MatrixDense_BLAS_lazyDuplicateTermsCancelOnSliceAssignment() {
+    let a = MatrixDenseBLAS<Double>([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]])
+    let b = MatrixDenseBLAS<Double>([[9.0, 8.0, 7.0], [6.0, 5.0, 4.0], [3.0, 2.0, 1.0]])
+    var destination = MatrixDenseBLAS<Double>(rows: 3, columns: 3)
+
+    destination[1..<3, 1..<3] = a[1..<3, 1..<3] + b[1..<3, 1..<3] - b[1..<3, 1..<3]
+
+    #expect(destination.toArray() == [[0.0, 0.0, 0.0], [0.0, 5.0, 6.0], [0.0, 8.0, 9.0]])
+}
+
 @Test func MatrixDense_BLAS_shapeBasedAccess() {
     var m = MatrixDenseBLAS<Double>(shape: [2, 3], elements: [1.0, 4.0, 2.0, 5.0, 3.0, 6.0])
 

--- a/Tests/TensorsTests/MatrixDenseBLASTests.swift
+++ b/Tests/TensorsTests/MatrixDenseBLASTests.swift
@@ -133,18 +133,18 @@ import Testing
     let matrix = MatrixDenseBLAS<Double>([[1.0, 2.0, 3.0, 4.0],
                                           [5.0, 6.0, 7.0, 8.0],
                                           [9.0, 10.0, 11.0, 12.0]])
-    let row: VectorFlatView<Double> = matrix[1, all]
+    let r: VectorFlatView<Double> = matrix[1, all]
 
-    #expect(row.elements == [5.0, 6.0, 7.0, 8.0])
+    #expect(r.elements == [5.0, 6.0, 7.0, 8.0])
 }
 
 @Test func MatrixDense_BLAS_subscriptSlicesColumnToVector() {
     let matrix = MatrixDenseBLAS<Double>([[1.0, 2.0, 3.0],
                                           [4.0, 5.0, 6.0],
                                           [7.0, 8.0, 9.0]])
-    let column: VectorFlatView<Double> = matrix[all, 1]
+    let c: VectorFlatView<Double> = matrix[all, 1]
 
-    #expect(column.elements == [2.0, 5.0, 8.0])
+    #expect(c.elements == [2.0, 5.0, 8.0])
 }
 
 private func complexTestMatrixA() -> MatrixDenseBLAS<ComplexDouble> {

--- a/Tests/TensorsTests/MatrixDenseTests.swift
+++ b/Tests/TensorsTests/MatrixDenseTests.swift
@@ -207,9 +207,9 @@ private func verifyInitializerWithRowsAndColumns<M: PluMatrix>(_ type: M.Type) w
     var matrix = M(rows: 2, columns: 3, initialValue: .zero)
     #expect(matrix.rows == 2)
     #expect(matrix.columns == 3)
-    for row in 0..<matrix.rows {
-        for column in 0..<matrix.columns {
-            #expect(matrix[row, column] == 0)
+    for i in 0..<matrix.rows {
+        for j in 0..<matrix.columns {
+            #expect(matrix[i, j] == 0)
         }
     }
     matrix[1, 2] = 3.14
@@ -264,9 +264,9 @@ private func verifyComplexMatrixMultiplication<M: PluMatrix>(_ type: M.Type) whe
 private func verifyTranspose<M: PluMatrix>(_ type: M.Type) where M.S == Double {
     let matrix = M([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
     let transposed = matrix.transpose()
-    for row in 0..<transposed.rows {
-        for column in 0..<transposed.columns {
-            #expect(transposed[row, column] == matrix[column, row])
+    for i in 0..<transposed.rows {
+        for j in 0..<transposed.columns {
+            #expect(transposed[i, j] == matrix[j, i])
         }
     }
 }

--- a/Tests/TensorsTests/MatrixDenseTests.swift
+++ b/Tests/TensorsTests/MatrixDenseTests.swift
@@ -89,10 +89,10 @@ enum MatrixImplementation: CaseIterable, CustomStringConvertible {
         }
     }
 
-    func checkApproximatelyEqual() {
+    func checkClose() {
         switch self {
-        case .reference: verifyApproximatelyEqual(MatrixDenseReference<Double>.self)
-        case .blas: verifyApproximatelyEqual(MatrixDenseBLAS<Double>.self)
+        case .reference: verifyClose(MatrixDenseReference<Double>.self)
+        case .blas: verifyClose(MatrixDenseBLAS<Double>.self)
         }
     }
 
@@ -167,8 +167,8 @@ func MatrixDense_tensorStructure(implementation: MatrixImplementation) {
 }
 
 @Test(arguments: MatrixImplementation.allCases)
-func MatrixDense_approximatelyEqual(implementation: MatrixImplementation) {
-    implementation.checkApproximatelyEqual()
+func MatrixDense_close(implementation: MatrixImplementation) {
+    implementation.checkClose()
 }
 
 @Test(arguments: MatrixImplementation.allCases)
@@ -289,12 +289,12 @@ private func verifyTensorStructure<M: PluMatrix>(_ type: M.Type) where M.S == Do
     #expect(matrix.rank == 2)
 }
 
-private func verifyApproximatelyEqual<M: PluMatrix>(_ type: M.Type) where M.S == Double {
+private func verifyClose<M: PluMatrix>(_ type: M.Type) where M.S == Double {
     let a = M([[1.0, 2.0], [3.0, 4.0]])
     let b = M([[1.0, 2.0], [3.0, 4.0 + 1e-14]])
     let c = M([[1.0, 2.0], [3.0, 5.0]])
-    #expect(a.isApproximatelyEqual(to: b, relativeTolerance: 1e-12, norm: { _ in 0.0 }))
-    #expect(!a.isApproximatelyEqual(to: c, relativeTolerance: 1e-12, norm: { _ in 0.0 }))
+    #expect(a.isClose(to: b, relativeTolerance: 1e-12))
+    #expect(!a.isClose(to: c, relativeTolerance: 1e-12))
 }
 
 private func verifyArithmetic<M: PluMatrix>(_ type: M.Type) where M.S == Double {

--- a/Tests/TensorsTests/MatrixFlatViewTests.swift
+++ b/Tests/TensorsTests/MatrixFlatViewTests.swift
@@ -41,24 +41,24 @@ import Testing
     let matrix = MatrixFlatView<Double>([[1.0, 2.0, 3.0, 4.0],
                                          [5.0, 6.0, 7.0, 8.0],
                                          [9.0, 10.0, 11.0, 12.0]])
-    let row: VectorFlatView<Double> = matrix.slice(row: 1, columns: SliceRange(0..<4, step: 2))
+    let r: VectorFlatView<Double> = matrix.slice(row: 1, columns: SliceRange(0..<4, step: 2))
 
-    #expect(row.view.storage === matrix.view.storage)
-    #expect(row.shape == [2])
-    #expect(row.elements == [5.0, 7.0])
-    #expect(!row.isContiguous)
+    #expect(r.view.storage === matrix.view.storage)
+    #expect(r.shape == [2])
+    #expect(r.elements == [5.0, 7.0])
+    #expect(!r.isContiguous)
 }
 
 @Test func MatrixFlatView_slicesColumnToVectorFlatView() {
     let matrix = MatrixFlatView<Double>([[1.0, 2.0, 3.0],
                                          [4.0, 5.0, 6.0],
                                          [7.0, 8.0, 9.0]])
-    let column: VectorFlatView<Double> = matrix.slice(rows: SliceRange(0..<3), column: 1)
+    let c: VectorFlatView<Double> = matrix.slice(rows: SliceRange(0..<3), column: 1)
 
-    #expect(column.view.storage === matrix.view.storage)
-    #expect(column.shape == [3])
-    #expect(column.elements == [2.0, 5.0, 8.0])
-    #expect(column.isContiguous)
+    #expect(c.view.storage === matrix.view.storage)
+    #expect(c.shape == [3])
+    #expect(c.elements == [2.0, 5.0, 8.0])
+    #expect(c.isContiguous)
 }
 
 @Test func MatrixFlatView_mutatingSliceCopiesOnWrite() {
@@ -87,18 +87,18 @@ import Testing
     let matrix = MatrixFlatView<Double>([[1.0, 2.0, 3.0, 4.0],
                                          [5.0, 6.0, 7.0, 8.0],
                                          [9.0, 10.0, 11.0, 12.0]])
-    let row: VectorFlatView<Double> = matrix[1, step(0..<4, by: 2)]
+    let r: VectorFlatView<Double> = matrix[1, step(0..<4, by: 2)]
 
-    #expect(row.elements == [5.0, 7.0])
+    #expect(r.elements == [5.0, 7.0])
 }
 
 @Test func MatrixFlatView_subscriptSlicesColumnToVector() {
     let matrix = MatrixFlatView<Double>([[1.0, 2.0, 3.0],
                                          [4.0, 5.0, 6.0],
                                          [7.0, 8.0, 9.0]])
-    let column: VectorFlatView<Double> = matrix[all, 1]
+    let c: VectorFlatView<Double> = matrix[all, 1]
 
-    #expect(column.elements == [2.0, 5.0, 8.0])
+    #expect(c.elements == [2.0, 5.0, 8.0])
 }
 
 @Test func MatrixFlatView_subscriptSlicesWithAllAndStep() {

--- a/Tests/TensorsTests/MatrixOperationsTests.swift
+++ b/Tests/TensorsTests/MatrixOperationsTests.swift
@@ -105,8 +105,8 @@ private func verifyEigenRealEigenvalues<M: MatrixEigen>(_ type: M.Type) where M.
     let eigen = matrix.eigen()
 
     expectEigenvalues(eigen.values, [ComplexDouble(2.0, 0.0), ComplexDouble(3.0, 0.0)])
-    expectEigenpair(matrix, eigen, column: 0)
-    expectEigenpair(matrix, eigen, column: 1)
+    expectEigenpair(matrix, eigen, j: 0)
+    expectEigenpair(matrix, eigen, j: 1)
 }
 
 private func verifyEigenComplexEigenvalues<M: MatrixEigen>(_ type: M.Type) where M.Eigenvalue == ComplexDouble {
@@ -115,8 +115,8 @@ private func verifyEigenComplexEigenvalues<M: MatrixEigen>(_ type: M.Type) where
     let eigen = matrix.eigen()
 
     expectEigenvalues(eigen.values, [ComplexDouble(0.0, 1.0), ComplexDouble(0.0, -1.0)])
-    expectEigenpair(matrix, eigen, column: 0)
-    expectEigenpair(matrix, eigen, column: 1)
+    expectEigenpair(matrix, eigen, j: 0)
+    expectEigenpair(matrix, eigen, j: 1)
 }
 
 private func expectEigenvalues(_ values: [ComplexDouble], _ expected: [ComplexDouble]) {
@@ -127,61 +127,61 @@ private func expectEigenvalues(_ values: [ComplexDouble], _ expected: [ComplexDo
 }
 
 private func expectEigenpair<M: MatrixEigen>(
-    _ matrix: M, _ eigen: Eigen<M.Eigenvalue, M.Eigenvectors>, column: Int
+    _ matrix: M, _ eigen: Eigen<M.Eigenvalue, M.Eigenvectors>, j: Int
 ) where M.Eigenvalue == ComplexDouble {
-    let vector = VectorDenseReference<ComplexDouble>((0..<matrix.rows).map { eigen.vectors[$0, column] })
+    let vector = VectorDenseReference<ComplexDouble>((0..<matrix.rows).map { eigen.vectors[$0, j] })
     let left = complexMatrix(matrix) * vector
-    let right = VectorDenseReference<ComplexDouble>((0..<vector.size).map { eigen.values[column] * vector[$0] })
+    let right = VectorDenseReference<ComplexDouble>((0..<vector.size).map { eigen.values[j] * vector[$0] })
 
     #expect(left.isClose(to: right, relativeTolerance: 1e-12))
 }
 
 private func complexMatrix<M: MatrixEigen>(_ matrix: M) -> MatrixDenseBLAS<ComplexDouble> {
-    MatrixDenseBLAS<ComplexDouble>((0..<matrix.rows).map { row in
-        (0..<matrix.columns).map { column in ComplexDouble(matrix[row, column], 0.0) }
+    MatrixDenseBLAS<ComplexDouble>((0..<matrix.rows).map { i in
+        (0..<matrix.columns).map { j in ComplexDouble(matrix[i, j], 0.0) }
     })
 }
 
 private func expectClose(_ matrix: MatrixDenseBLAS<Double>, _ expected: [[Double]], tolerance: Double) {
-    for row in 0..<matrix.rows {
-        for column in 0..<matrix.columns {
-            #expect(abs(matrix[row, column] - expected[row][column]) <= tolerance)
+    for i in 0..<matrix.rows {
+        for j in 0..<matrix.columns {
+            #expect(abs(matrix[i, j] - expected[i][j]) <= tolerance)
         }
     }
 }
 
 private func expectCloseToIdentity(_ matrix: MatrixDenseBLAS<Double>, tolerance: Double) {
-    for row in 0..<matrix.rows {
-        for column in 0..<matrix.columns {
-            let expected = row == column ? 1.0 : 0.0
-            #expect(abs(matrix[row, column] - expected) <= tolerance)
+    for i in 0..<matrix.rows {
+        for j in 0..<matrix.columns {
+            let expected = i == j ? 1.0 : 0.0
+            #expect(abs(matrix[i, j] - expected) <= tolerance)
         }
     }
 }
 
 private func expectCloseToIdentity(_ matrix: MatrixDenseBLAS<Float>, tolerance: Float) {
-    for row in 0..<matrix.rows {
-        for column in 0..<matrix.columns {
-            let expected: Float = row == column ? 1.0 : 0.0
-            #expect(abs(matrix[row, column] - expected) <= tolerance)
+    for i in 0..<matrix.rows {
+        for j in 0..<matrix.columns {
+            let expected: Float = i == j ? 1.0 : 0.0
+            #expect(abs(matrix[i, j] - expected) <= tolerance)
         }
     }
 }
 
 private func expectCloseToIdentity(_ matrix: MatrixDenseBLAS<ComplexDouble>, tolerance: Double) {
-    for row in 0..<matrix.rows {
-        for column in 0..<matrix.columns {
-            let expected = row == column ? ComplexDouble(1.0, 0.0) : .zero
-            #expect((matrix[row, column] - expected).mod <= tolerance)
+    for i in 0..<matrix.rows {
+        for j in 0..<matrix.columns {
+            let expected = i == j ? ComplexDouble(1.0, 0.0) : .zero
+            #expect((matrix[i, j] - expected).mod <= tolerance)
         }
     }
 }
 
 private func expectCloseToIdentity(_ matrix: MatrixDenseBLAS<ComplexFloat>, tolerance: Float) {
-    for row in 0..<matrix.rows {
-        for column in 0..<matrix.columns {
-            let expected = row == column ? ComplexFloat(1.0, 0.0) : .zero
-            #expect((matrix[row, column] - expected).mod <= tolerance)
+    for i in 0..<matrix.rows {
+        for j in 0..<matrix.columns {
+            let expected = i == j ? ComplexFloat(1.0, 0.0) : .zero
+            #expect((matrix[i, j] - expected).mod <= tolerance)
         }
     }
 }

--- a/Tests/TensorsTests/MatrixOperationsTests.swift
+++ b/Tests/TensorsTests/MatrixOperationsTests.swift
@@ -17,8 +17,8 @@ import Testing
     let identity = MatrixDenseBLAS<Double>.identity(size: 2)
 
     #expect(identity.toArray() == [[1.0, 0.0], [0.0, 1.0]])
-    expectApproximatelyEqual(inverse, [[-2.0, 1.0], [1.5, -0.5]], tolerance: 1e-12)
-    expectApproximatelyIdentity(matrix * inverse, tolerance: 1e-12)
+    expectClose(inverse, [[-2.0, 1.0], [1.5, -0.5]], tolerance: 1e-12)
+    expectCloseToIdentity(matrix * inverse, tolerance: 1e-12)
 }
 
 @Test func Matrix_BLAS_lapackDeterminantAndInverse() {
@@ -26,8 +26,8 @@ import Testing
                                           [3.0, 6.0, 1.0],
                                           [2.0, 5.0, 1.0]])
 
-    #expect(matrix.det.isApproximatelyEqual(to: 3.0, relativeTolerance: 1e-12))
-    expectApproximatelyIdentity(matrix * matrix.inverse(), tolerance: 1e-12)
+    #expect(matrix.det.isClose(to: 3.0, relativeTolerance: 1e-12))
+    expectCloseToIdentity(matrix * matrix.inverse(), tolerance: 1e-12)
 }
 
 @Test func Matrix_BLAS_lapackSingularDeterminant() {
@@ -42,24 +42,24 @@ import Testing
                                          [3.0, 6.0, 1.0],
                                          [2.0, 5.0, 1.0]])
 
-    #expect(matrix.det.isApproximatelyEqual(to: 3.0, relativeTolerance: 1e-5))
-    expectApproximatelyIdentity(matrix * matrix.inverse(), tolerance: 1e-5)
+    #expect(matrix.det.isClose(to: 3.0, relativeTolerance: 1e-5))
+    expectCloseToIdentity(matrix * matrix.inverse(), tolerance: 1e-5)
 }
 
 @Test func Matrix_BLAS_lapackComplexDeterminantAndInverse() {
     let matrix = MatrixDenseBLAS<ComplexDouble>([[ComplexDouble(1.0, 1.0), ComplexDouble(2.0, 0.0)],
                                                  [ComplexDouble(0.0, 0.0), ComplexDouble(3.0, -1.0)]])
 
-    #expect((matrix.det - ComplexDouble(4.0, 2.0)).mod.isApproximatelyEqual(to: 0.0, relativeTolerance: 1e-12))
-    expectApproximatelyIdentity(matrix * matrix.inverse(), tolerance: 1e-12)
+    #expect((matrix.det - ComplexDouble(4.0, 2.0)).mod.isClose(to: 0.0, relativeTolerance: 1e-12))
+    expectCloseToIdentity(matrix * matrix.inverse(), tolerance: 1e-12)
 }
 
 @Test func Matrix_BLAS_lapackComplexFloatDeterminantAndInverse() {
     let matrix = MatrixDenseBLAS<ComplexFloat>([[ComplexFloat(1.0, 1.0), ComplexFloat(2.0, 0.0)],
                                                 [ComplexFloat(0.0, 0.0), ComplexFloat(3.0, -1.0)]])
 
-    #expect((matrix.det - ComplexFloat(4.0, 2.0)).mod.isApproximatelyEqual(to: 0.0, relativeTolerance: 1e-5))
-    expectApproximatelyIdentity(matrix * matrix.inverse(), tolerance: 1e-5)
+    #expect((matrix.det - ComplexFloat(4.0, 2.0)).mod.isClose(to: 0.0, relativeTolerance: 1e-5))
+    expectCloseToIdentity(matrix * matrix.inverse(), tolerance: 1e-5)
 }
 
 #if canImport(Accelerate)
@@ -68,8 +68,8 @@ import Testing
     let accelerate = MatrixDenseBLAS(rows: 3, columns: 3, values: values, blasImplementation: .accelerate)
     let openBLAS = MatrixDenseBLAS(rows: 3, columns: 3, values: values, blasImplementation: .openBLAS)
 
-    #expect(accelerate.det.isApproximatelyEqual(to: openBLAS.det, relativeTolerance: 1e-12))
-    #expect(accelerate.inverse().isApproximatelyEqual(to: openBLAS.inverse(), relativeTolerance: 1e-12))
+    #expect(accelerate.det.isClose(to: openBLAS.det, relativeTolerance: 1e-12))
+    #expect(accelerate.inverse().isClose(to: openBLAS.inverse(), relativeTolerance: 1e-12))
 }
 #endif
 
@@ -122,7 +122,7 @@ private func verifyEigenComplexEigenvalues<M: MatrixEigen>(_ type: M.Type) where
 private func expectEigenvalues(_ values: [ComplexDouble], _ expected: [ComplexDouble]) {
     #expect(values.count == expected.count)
     for value in expected {
-        #expect(values.contains { $0.isApproximatelyEqual(to: value, relativeTolerance: 1e-12) })
+        #expect(values.contains { $0.isClose(to: value, relativeTolerance: 1e-12) })
     }
 }
 
@@ -133,7 +133,7 @@ private func expectEigenpair<M: MatrixEigen>(
     let left = complexMatrix(matrix) * vector
     let right = VectorDenseReference<ComplexDouble>((0..<vector.size).map { eigen.values[column] * vector[$0] })
 
-    #expect(left.isApproximatelyEqual(to: right, relativeTolerance: 1e-12))
+    #expect(left.isClose(to: right, relativeTolerance: 1e-12))
 }
 
 private func complexMatrix<M: MatrixEigen>(_ matrix: M) -> MatrixDenseBLAS<ComplexDouble> {
@@ -142,7 +142,7 @@ private func complexMatrix<M: MatrixEigen>(_ matrix: M) -> MatrixDenseBLAS<Compl
     })
 }
 
-private func expectApproximatelyEqual(_ matrix: MatrixDenseBLAS<Double>, _ expected: [[Double]], tolerance: Double) {
+private func expectClose(_ matrix: MatrixDenseBLAS<Double>, _ expected: [[Double]], tolerance: Double) {
     for row in 0..<matrix.rows {
         for column in 0..<matrix.columns {
             #expect(abs(matrix[row, column] - expected[row][column]) <= tolerance)
@@ -150,7 +150,7 @@ private func expectApproximatelyEqual(_ matrix: MatrixDenseBLAS<Double>, _ expec
     }
 }
 
-private func expectApproximatelyIdentity(_ matrix: MatrixDenseBLAS<Double>, tolerance: Double) {
+private func expectCloseToIdentity(_ matrix: MatrixDenseBLAS<Double>, tolerance: Double) {
     for row in 0..<matrix.rows {
         for column in 0..<matrix.columns {
             let expected = row == column ? 1.0 : 0.0
@@ -159,7 +159,7 @@ private func expectApproximatelyIdentity(_ matrix: MatrixDenseBLAS<Double>, tole
     }
 }
 
-private func expectApproximatelyIdentity(_ matrix: MatrixDenseBLAS<Float>, tolerance: Float) {
+private func expectCloseToIdentity(_ matrix: MatrixDenseBLAS<Float>, tolerance: Float) {
     for row in 0..<matrix.rows {
         for column in 0..<matrix.columns {
             let expected: Float = row == column ? 1.0 : 0.0
@@ -168,7 +168,7 @@ private func expectApproximatelyIdentity(_ matrix: MatrixDenseBLAS<Float>, toler
     }
 }
 
-private func expectApproximatelyIdentity(_ matrix: MatrixDenseBLAS<ComplexDouble>, tolerance: Double) {
+private func expectCloseToIdentity(_ matrix: MatrixDenseBLAS<ComplexDouble>, tolerance: Double) {
     for row in 0..<matrix.rows {
         for column in 0..<matrix.columns {
             let expected = row == column ? ComplexDouble(1.0, 0.0) : .zero
@@ -177,7 +177,7 @@ private func expectApproximatelyIdentity(_ matrix: MatrixDenseBLAS<ComplexDouble
     }
 }
 
-private func expectApproximatelyIdentity(_ matrix: MatrixDenseBLAS<ComplexFloat>, tolerance: Float) {
+private func expectCloseToIdentity(_ matrix: MatrixDenseBLAS<ComplexFloat>, tolerance: Float) {
     for row in 0..<matrix.rows {
         for column in 0..<matrix.columns {
             let expected = row == column ? ComplexFloat(1.0, 0.0) : .zero

--- a/Tests/TensorsTests/ScalarTests.swift
+++ b/Tests/TensorsTests/ScalarTests.swift
@@ -16,9 +16,9 @@ import Testing
     #expect(-a == ComplexDouble(-1.2, 2.3))
     #expect(a+b == ComplexDouble(4.6, 3.3))
     #expect(a+b == b+a)
-    #expect((a-b).isApproximatelyEqual(to: ComplexDouble(-2.2, -7.9)))
-    #expect((a*b).isApproximatelyEqual(to: ComplexDouble(16.96, -1.1)))
-    #expect((a/b).isApproximatelyEqual(to: ComplexDouble(-0.20503261882572227, -0.3387698042870456)))
+    #expect((a-b).isClose(to: ComplexDouble(-2.2, -7.9)))
+    #expect((a*b).isClose(to: ComplexDouble(16.96, -1.1)))
+    #expect((a/b).isClose(to: ComplexDouble(-0.20503261882572227, -0.3387698042870456)))
 }
 
 @Test func Complex_mixedRealArithmetic() {
@@ -30,8 +30,8 @@ import Testing
     #expect(z - 5.0 == ComplexDouble(-2.0, -2.0))
     #expect(5.0 * z == ComplexDouble(15.0, -10.0))
     #expect(z * 5.0 == ComplexDouble(15.0, -10.0))
-    #expect((5.0 / z).isApproximatelyEqual(to: ComplexDouble(15.0/13.0, 10.0/13.0)))
-    #expect((z / 5.0).isApproximatelyEqual(to: ComplexDouble(0.6, -0.4)))
+    #expect((5.0 / z).isClose(to: ComplexDouble(15.0/13.0, 10.0/13.0)))
+    #expect((z / 5.0).isClose(to: ComplexDouble(0.6, -0.4)))
 }
 
 @Test func Complex_plumeriaScalarProperties() {
@@ -40,7 +40,7 @@ import Testing
     #expect(ComplexDouble.i == ComplexDouble(0.0, 1.0))
     #expect(z.star == ComplexDouble(3.0, -4.0))
     #expect(z.mod == 5.0)
-    #expect(z.arg.isApproximatelyEqual(to: 0.9272952180016122, relativeTolerance: 1e-15))
+    #expect(z.arg.isClose(to: 0.9272952180016122, relativeTolerance: 1e-15))
 }
 
 @Test func Complex_imaginaryUnitSupportsLocalMathNotation() {

--- a/Tests/TensorsTests/TensorDenseTests.swift
+++ b/Tests/TensorsTests/TensorDenseTests.swift
@@ -331,7 +331,7 @@ private func verifyElementwiseArithmetic<T: TensorDenseTestImplementation>(_ typ
     #expect(scaledRight[[1, 1, 0]] == -4.0)
     #expect(scaledLeft == scaledRight)
     #expect(divided[[0, 0, 1]] == -0.5)
-    #expect(sum.isApproximatelyEqual(to: sum, relativeTolerance: 1e-12, norm: { _ in 0.0 }))
+    #expect(sum.isClose(to: sum, relativeTolerance: 1e-12))
 }
 
 private func verifyIndexMultiply<T: TensorDenseTestImplementation>(_ type: T.Type) {

--- a/Tests/TensorsTests/TensorMultiplicationTests.swift
+++ b/Tests/TensorsTests/TensorMultiplicationTests.swift
@@ -31,8 +31,8 @@ private struct TestTensor<S: PluScalar>: TensorMultiplication {
     private static func linearIndex(_ indices: [Int], shape: [Int]) -> Int {
         var stride = 1
         var flatIndex = 0
-        for (index, dimension) in zip(indices, shape) {
-            flatIndex += index * stride
+        for (i, dimension) in zip(indices, shape) {
+            flatIndex += i * stride
             stride *= dimension
         }
         return flatIndex


### PR DESCRIPTION
Closes #79

## Changes
- Normalize duplicate `LazyMatrix` terms before materialization and slice assignment, so expressions such as `A + B - B` collapse matching storage views into a single effective term.
- Add row-contiguous planned assignment paths that replace the brittle seven-term special case with reusable term planning for single-storage and two-storage lazy expressions.
- Add focused tests covering lazy duplicate-term cancellation for full materialization and slice assignment.
- Rename approximate equality APIs from `isApproximatelyEqual` to `isClose`, with protocol-level convenience overloads.
- Rename complex storage conversion from `complexValues` to `toComplex`.
- Rename tensor, matrix, and vector local indexing variables toward math-style `i`/`j` notation across implementation, benchmarks, and tests.
- Document Swift and NumPy benchmark findings in `BENCHMARKS.md`, including that NumPy does not eliminate `A + B - B` as an algebraic expression.